### PR TITLE
Dark mode chat theme: near‑black conversation + restored input grey (scoped to /chat)

### DIFF
--- a/apps/web/app/chat/layout.tsx
+++ b/apps/web/app/chat/layout.tsx
@@ -8,7 +8,7 @@ export default function ChatPageLayout({
     params: { threadId: string };
 }) {
     return (
-        <div className="relative flex h-full w-full flex-col">
+        <div className="chat-theme relative flex h-full w-full flex-col">
             {children}
             <AnimatedChatInput />
         </div>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -117,6 +117,15 @@
 }
 
 @layer base {
+    .dark .chat-theme {
+        --secondary: 0 0% 2%;
+        --background: 0 0% 8%;
+        --border: 0 0% 12%;
+        --hard: 0 0% 18%;
+    }
+}
+
+@layer base {
     * {
         @apply border-border;
     }

--- a/packages/common/components/layout/root.tsx
+++ b/packages/common/components/layout/root.tsx
@@ -10,7 +10,7 @@ import { useRootContext } from '@repo/common/context';
 import { AgentProvider } from '@repo/common/hooks';
 import { useAppStore } from '@repo/common/store';
 import { plausible } from '@repo/shared/utils';
-import { Badge, Button, Flex, Toaster } from '@repo/ui';
+import { Badge, Button, Flex, Toaster, cn } from '@repo/ui';
 import { IconMoodSadDizzy, IconX } from '@tabler/icons-react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { usePathname } from 'next/navigation';
@@ -28,6 +28,9 @@ export const RootLayout: FC<TRootLayout> = ({ children }) => {
 
     const containerClass =
         'relative flex flex-1 flex-row h-[calc(99dvh)] border border-border rounded-sm bg-secondary w-full overflow-hidden shadow-sm';
+
+    const pathname = usePathname();
+    const isChat = pathname.startsWith('/chat');
 
     useEffect(() => {
         plausible.trackPageview();
@@ -68,7 +71,7 @@ export const RootLayout: FC<TRootLayout> = ({ children }) => {
             <Flex className="flex-1 overflow-hidden">
                 <motion.div className="flex w-full py-1 pr-1">
                     <AgentProvider>
-                        <div className={containerClass}>
+                        <div className={cn(containerClass, isChat && 'chat-theme')}>
                             <div className="relative flex h-full w-0 flex-1 flex-row">
                                 <div className="flex w-full flex-col gap-2 overflow-y-auto">
                                     <div className="from-secondary to-secondary/0 via-secondary/70 absolute left-0 right-0 top-0 z-40 flex flex-row items-center justify-center gap-1 bg-gradient-to-b p-2 pb-12"></div>


### PR DESCRIPTION
Summary (why)\n- Ensure chat conversation area is near‑black in dark mode without altering bubbles/contrast.\n- Restore the previous grey for the chat input card to improve separation.\n- Scope changes strictly to /chat to avoid regressions elsewhere; light mode untouched.\n\nChanges (what)\n- apps/web/app/globals.css: Add .dark .chat-theme CSS vars to override surfaces: --secondary: 0 0% 2%, --background: 0 0% 8%, --border: 0 0% 12%, --hard: 0 0% 18%.\n- packages/common/components/layout/root.tsx: Conditionally apply 'chat-theme' when pathname starts with '/chat' using usePathname + cn.\n- apps/web/app/chat/layout.tsx: Add 'chat-theme' to the page wrapper to ensure variable inheritance.\n\nImpact\n- Only dark mode on /chat and /chat/[threadId] affected.\n- Conversation bg (bg-secondary) becomes hsl(0 0% 2%).\n- Input card (bg-background) becomes hsl(0 0% 8%).\n- Borders/dividers slightly lighter via --border/--hard.\n- Message bubbles and readability unchanged.\n\nManual verification\n- Visit /chat and /chat/[threadId] in dark mode to confirm the above.\n- Sidebar and non-chat pages should look unchanged; light mode unaffected.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/4676933c-85de-419f-bf19-e5571c413606/task/0369b022-cd6b-44dd-a53b-18b6c129659c))