### PR TITLE
feat(chat): add light-mode chat theme variables and scope AI_Prompt under .chat-theme

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -130,6 +130,14 @@
 }
 
 @layer base {
+    .chat-theme {
+        --chat-input-container-bg: 210 20% 98%;
+        --chat-input-surface-bg: 0 0% 100%;
+        --chat-input-border: 220 13% 91%;
+    }
+}
+
+@layer base {
     * {
         @apply border-border;
     }

--- a/packages/common/components/chat-input/animated-input.tsx
+++ b/packages/common/components/chat-input/animated-input.tsx
@@ -305,7 +305,7 @@ export const AnimatedChatInput = ({
     const renderChatInput = () => (
         <AnimatePresence>
             <motion.div
-                className="w-full px-3"
+                className="w-full px-3 chat-theme"
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 key={`chat-input`}


### PR DESCRIPTION
Implements Option A (theme variables) so AI_Prompt renders the intended colors in light mode without breaking dark mode.\n\nChanges:\n- apps/web/app/globals.css: add light-mode variables under @layer base .chat-theme with explicit HSL values:\n  - --chat-input-container-bg: 210 20% 98% (#F3F4F6)\n  - --chat-input-surface-bg: 0 0% 100% (#FFFFFF)\n  - --chat-input-border: 220 13% 91% (#E5E7EB)\n  Existing .dark .chat-theme block remains unchanged.\n- packages/common/components/chat-input/animated-input.tsx: add  to the motion.div wrapper (w-full px-3) so AI_Prompt resolves vars.\n\nNotes:\n- ThemeProvider config unchanged (class strategy, defaultTheme=light).\n- AI_Prompt component code unchanged; inline styles already read from CSS variables.\n\nAcceptance criteria:\n- Light mode: container #F3F4F6, surface #FFFFFF, border #E5E7EB.\n- Dark mode: no regressions; existing .dark .chat-theme values apply when html has .dark.\n- No visual change to other components.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/54667697-e62e-4b6d-8875-7427e5701412/task/b8fa9aa6-4bcb-4681-bf76-6177aacca778))