### PR TITLE
feat(ui): make DropdownMenuContent colors adapt to chat theme vars\n\…

### DIFF
--- a/packages/ui/src/components/animated-ai-input.tsx
+++ b/packages/ui/src/components/animated-ai-input.tsx
@@ -257,8 +257,10 @@ export function AI_Prompt({
 
     const selectedModelData = models.find(m => m.id === selectedModel);
 
+    const portalRef = useRef<HTMLDivElement>(null);
+
     return (
-        <div className="w-full">
+        <div className="w-full" ref={portalRef}>
             <ShineBorder
                 className="w-full p-0"
                 borderRadius={16}
@@ -337,10 +339,14 @@ export function AI_Prompt({
                                                 <DropdownMenuContent
                                                     className={cn(
                                                         "min-w-[10rem]",
-                                                        "border-[#e5e7eb] dark:border-gray-700",
-                                                        "bg-white dark:bg-gray-800",
                                                         "shadow-lg"
                                                     )}
+                                                    container={portalRef.current ?? undefined}
+                                                    style={{
+                                                        backgroundColor: 'hsl(var(--chat-input-surface-bg))',
+                                                        borderColor: 'hsl(var(--chat-input-border))',
+                                                        boxShadow: 'var(--chat-input-surface-shadow)'
+                                                    }}
                                                 >
                                                     {models.map((model) => (
                                                         <DropdownMenuItem

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -57,9 +57,9 @@ DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayNam
 
 const DropdownMenuContent = React.forwardRef<
     React.ElementRef<typeof DropdownMenuPrimitive.Content>,
-    React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-    <DropdownMenuPrimitive.Portal>
+    React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> & { container?: HTMLElement }
+>(({ className, sideOffset = 4, container, ...props }, ref) => (
+    <DropdownMenuPrimitive.Portal container={container}>
         <DropdownMenuPrimitive.Content
             ref={ref}
             sideOffset={sideOffset}


### PR DESCRIPTION
…n- Add optional  prop to DropdownMenuContent (Portal target)\n- In AI_Prompt, portal into a local container under .chat-theme\n- Style dropdown content via CSS vars: surface bg + border + shadow