### PR TITLE
Révision de Prix: show ‘Bientôt disponible’ badge and block selection in model dropdown

### DIFF
--- a/packages/common/components/chat-input/animated-input.tsx
+++ b/packages/common/components/chat-input/animated-input.tsx
@@ -8,7 +8,7 @@ import {
 } from '@repo/common/components';
 import { useImageAttachment } from '@repo/common/hooks';
 import { CHAT_MODE_CREDIT_COSTS, ChatMode, ChatModeConfig, getChatModeName } from '@repo/shared/config';
-import { cn, Flex, AI_Prompt, ModelIcons } from '@repo/ui';
+import { cn, Flex, AI_Prompt, ModelIcons, useToast } from '@repo/ui';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useParams, usePathname, useRouter } from 'next/navigation';
 import React, { useEffect } from 'react';
@@ -17,7 +17,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useAgentStream } from '../../hooks/agent-provider';
 import { useChatStore } from '../../store';
 import { ExamplePrompts } from '../exmaple-prompts';
-import { NewIcon } from '../icons';
+import { NewIcon, ComingSoonIcon } from '../icons';
 import {
     IconAtom,
     IconNorthStar,
@@ -48,6 +48,8 @@ export const AnimatedChatInput = ({
     const isChatPage = usePathname().startsWith('/chat');
     const imageAttachments = useChatStore(state => state.imageAttachments);
     const clearImageAttachments = useChatStore(state => state.clearImageAttachments);
+
+    const { toast } = useToast();
 
     const stopGeneration = useChatStore(state => state.stopGeneration);
     const { dropzonProps, readImageFile } = useImageAttachment();
@@ -230,15 +232,19 @@ export const AnimatedChatInput = ({
     const activeModels = AI_MODELS.filter(model => !model.id.includes('//'));
 
     // Add credit cost and auth badge to model names
-    const modelsWithBadges = activeModels.map(model => ({
-        ...model,
-        name: (
-            <div className="flex items-center gap-2">
-                <span>{model.name}</span>
-                {ChatModeConfig[model.id]?.isNew && <NewIcon />}
-            </div>
-        ),
-    }));
+    const modelsWithBadges = activeModels.map(model => {
+        const isRevision = model.id === ChatMode.REVISION_DE_PRIX;
+        return {
+            ...model,
+            icon: isRevision ? <div className="opacity-50 cursor-not-allowed">{model.icon}</div> : model.icon,
+            name: (
+                <div className={cn("flex items-center gap-2", isRevision && "opacity-50 cursor-not-allowed")}> 
+                    <span>{model.name}</span>
+                    {isRevision ? <ComingSoonIcon /> : ChatModeConfig[model.id]?.isNew && <NewIcon />}
+                </div>
+            ),
+        };
+    });
 
     const sendMessage = async (value: string, modelId: string) => {
         if (!value.trim()) return;
@@ -298,7 +304,10 @@ export const AnimatedChatInput = ({
     };
 
     const handleModelChange = (modelId: string) => {
-        // Convert string to ChatMode enum
+        if (modelId === ChatMode.REVISION_DE_PRIX) {
+            toast({ title: 'Bientôt disponible' });
+            return;
+        }
         setChatMode(modelId as ChatMode);
     };
 

--- a/packages/common/components/icons.tsx
+++ b/packages/common/components/icons.tsx
@@ -49,6 +49,12 @@ export const NewIcon = () => {
     );
 };
 
+export const ComingSoonIcon = () => (
+    <div className="flex-inline flex h-5 items-center justify-center gap-1 rounded-md bg-emerald-500/20 p-0.5 px-1 font-mono text-xs font-medium text-emerald-500">
+        Bientôt disponible
+    </div>
+);
+
 export const CreditIcon = ({
     credits,
     variant = 'default',


### PR DESCRIPTION
Summary
- Communicate upcoming availability of the “Révision de Prix” mode while keeping it visible in the model menu.
- Prevent accidental selection and state changes; inform users with a small toast instead.

Changes
- packages/common/components/icons.tsx
  - Added ComingSoonIcon component with the same styling footprint as NewIcon; label: “Bientôt disponible”.
- packages/common/components/chat-input/animated-input.tsx
  - Imported useToast from @repo/ui and ComingSoonIcon from ../icons.
  - modelsWithBadges: For ChatMode.REVISION_DE_PRIX, show <ComingSoonIcon /> instead of the default New badge; keep New badges for other modes.
  - Styled “Révision de Prix” entry as visually disabled (opacity-50 cursor-not-allowed) by wrapping the icon/name so it appears grayed out in the dropdown.
  - Guarded handleModelChange: if ChatMode.REVISION_DE_PRIX is selected, show toast “Bientôt disponible” and return early without calling setChatMode.

Notes
- No changes to AI_Prompt (packages/ui/src/components/animated-ai-input.tsx) to keep generic UI behavior for other contexts.
- No changes to ChatModeConfig / isNew flags; the badge override is isolated to the wrapper only.
- Root Toaster already mounted; using @repo/ui’s useToast to show the message.

Acceptance criteria coverage
- ‘Révision de Prix’ is visible in the model dropdown and appears disabled (grayed).
- Displays ‘Bientôt disponible’ badge instead of ‘New’.
- Clicking it shows a toast “Bientôt disponible” and does not change the active model (store’s setChatMode is guarded).
- Other models retain existing ‘New’ badges where applicable.

Impact
- UX enhancement only; does not affect message sending, image attachments, or other models.



₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/33142fda-3c1e-48a6-bba0-12440191fcc2/task/f039b75c-88f6-4804-b55a-a07d91118862))