### PR TITLE
Replace pink (#EC4899) with light orange (#FDBA74) in AI_Prompt ShineBorder gradient

### DIFF
--- a/packages/ui/src/components/animated-ai-input.tsx
+++ b/packages/ui/src/components/animated-ai-input.tsx
@@ -272,7 +272,7 @@ export function AI_Prompt({
                 borderRadius={16}
                 borderWidth={2}
                 duration={10}
-                color={["#3B82F6", "#8B5CF6", "#EC4899"]}
+                color={["#3B82F6", "#8B5CF6", "#FDBA74"]}
             >
                 <div className="bg-gray-100 dark:bg-gray-900 rounded-2xl p-1.5 border border-[#e5e7eb] dark:border-gray-800" style={{ backgroundColor: 'hsl(var(--chat-input-container-bg))', borderColor: 'hsl(var(--chat-input-border))' }}>
                     <div className="relative">


### PR DESCRIPTION
Summary
- Replace pink (#EC4899) with light orange (#FDBA74) in AI_Prompt’s ShineBorder gradient, scoped strictly to AI_Prompt as requested.

Changes
- packages/ui/src/components/animated-ai-input.tsx
  - Updated ShineBorder color array:
    - Before: color={["#3B82F6", "#8B5CF6", "#EC4899"]}
    - After:  color={["#3B82F6", "#8B5CF6", "#FDBA74"]}

Nature of change
- UI tweak only. No logic, layout, or component structure changes.

Impact
- AI_Prompt’s border shine now uses blue (#3B82F6), purple (#8B5CF6), and light orange (#FDBA74).
- No other components or files are affected.

Acceptance criteria checklist
- [x] AI_Prompt uses #3B82F6, #8B5CF6, #FDBA74.
- [x] No #EC4899 remains in AI_Prompt’s ShineBorder color array.
- [x] No changes to ShineBorder component implementation or global styles.
- [x] No TypeScript/JSX errors introduced.

Verification
- Open a view rendering AI_Prompt and confirm the gradient shows the new light orange accent.
- Optional: search for “#EC4899” in animated-ai-input.tsx to confirm it no longer appears.

Why
- Aligns the AI_Prompt accent with the requested palette while keeping the change isolated to this component.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/33142fda-3c1e-48a6-bba0-12440191fcc2/task/24f2c776-d605-410e-9d90-f560008a12db))