### PR TITLE
Increase AI_Prompt shine accent saturation by switching orange to #F9…

### DIFF
--- a/packages/ui/src/components/animated-ai-input.tsx
+++ b/packages/ui/src/components/animated-ai-input.tsx
@@ -272,7 +272,7 @@ export function AI_Prompt({
                 borderRadius={16}
                 borderWidth={2}
                 duration={10}
-                color={["#3B82F6", "#8B5CF6", "#FDBA74"]}
+                color={["#3B82F6", "#8B5CF6", "#F97316"]}
             >
                 <div className="bg-gray-100 dark:bg-gray-900 rounded-2xl p-1.5 border border-[#e5e7eb] dark:border-gray-800" style={{ backgroundColor: 'hsl(var(--chat-input-container-bg))', borderColor: 'hsl(var(--chat-input-border))' }}>
                     <div className="relative">


### PR DESCRIPTION
…7316 for clearer emphasis; scope limited to AI_Prompt usage