### PR TITLE
feat(ui): animated web search button (rotate + label) across eligible models

### DIFF
--- a/packages/ui/src/components/animated-ai-input.tsx
+++ b/packages/ui/src/components/animated-ai-input.tsx
@@ -377,21 +377,43 @@ export function AI_Prompt({
                                     {showWebToggle && (
                                         <button
                                             type="button"
+                                            onClick={() => !disabled && onToggleWebSearch?.()}
+                                            aria-pressed={!!webSearchEnabled}
+                                            aria-label="Toggle web search"
                                             className={cn(
-                                                "rounded-lg p-2",
+                                                "rounded-lg transition-all flex items-center gap-1 px-2 py-1 h-8 border",
                                                 "bg-[hsl(var(--chat-input-control-bg))] hover:bg-[hsl(var(--chat-input-control-hover-bg))]",
                                                 "focus-visible:ring-2 focus-visible:ring-offset-0 focus-visible:ring-[hsl(var(--chat-input-border))]",
-                                                "transition-colors",
                                                 webSearchEnabled
-                                                    ? "text-blue-600 dark:text-blue-400"
-                                                    : "text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white",
+                                                    ? "border-blue-500 text-blue-600 dark:text-blue-400"
+                                                    : "border-transparent text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white",
                                                 disabled && "opacity-50 cursor-not-allowed"
                                             )}
-                                            aria-label="Web search"
-                                            onClick={() => !disabled && onToggleWebSearch?.()}
                                             disabled={disabled}
                                         >
-                                            <Globe className="w-4 h-4" />
+                                            <div className="w-5 h-5 flex items-center justify-center">
+                                                <motion.div
+                                                    animate={{ rotate: webSearchEnabled ? 360 : 0, scale: webSearchEnabled ? 1.1 : 1 }}
+                                                    whileHover={{ scale: 1.1, transition: { type: "spring", stiffness: 300 } }}
+                                                    transition={{ type: "spring", stiffness: 260, damping: 20 }}
+                                                >
+                                                    <Globe className="w-4 h-4" />
+                                                </motion.div>
+                                            </div>
+
+                                            <AnimatePresence>
+                                                {webSearchEnabled && (
+                                                    <motion.span
+                                                        initial={{ width: 0, opacity: 0 }}
+                                                        animate={{ width: "auto", opacity: 1 }}
+                                                        exit={{ width: 0, opacity: 0 }}
+                                                        transition={{ duration: 0.2 }}
+                                                        className="text-xs overflow-hidden whitespace-nowrap"
+                                                    >
+                                                        Search
+                                                    </motion.span>
+                                                )}
+                                            </AnimatePresence>
                                         </button>
                                     )}
                                     {onAttachFile && (


### PR DESCRIPTION
This PR adds an animated Web Search toggle to the AI_Prompt component and applies it automatically to all models that already expose the control via existing gating.

What’s included
- Animated Web Search button in packages/ui/src/components/animated-ai-input.tsx.
- Globe icon wrapped in framer-motion with rotate (0→360°) and slight scale (1→1.1) when enabled.
- whileHover scale 1.1 with spring transition (stiffness ~300, damping ~20/stiffness 260 for main transition).
- Animated "Search" label with AnimatePresence: width 0→auto and opacity 0→1 on enter, and reversed on exit; overflow-hidden + whitespace-nowrap to avoid layout jumps.
- Styles follow existing blue palette for active state: text-blue-600 dark:text-blue-400 + border-blue-500; inactive uses gray palette; background uses existing CSS variables bg-[hsl(var(--chat-input-control-bg))] and hover.
- Accessibility: aria-pressed bound to webSearchEnabled and aria-label="Toggle web search". Click handler preserved and disabled respected.
- No changes to gating logic or public props; uses showWebToggle, webSearchEnabled, onToggleWebSearch, disabled.

Acceptance criteria
- When showWebToggle is true, the button renders without visual regressions.
- On click, onToggleWebSearch is triggered; when webSearchEnabled becomes true, Globe animates a 360° rotation and scales to 1.1.
- The "Search" label appears/disappears smoothly via AnimatePresence without noticeable layout jump.
- Active state uses text-blue-600 dark:text-blue-400 and border-blue-500; inactive uses existing gray styling.
- Works in light and dark themes; when disabled, the button does not interact.
- No change to gating: animation is present for all models that already expose the button.

Files changed
- packages/ui/src/components/animated-ai-input.tsx only.

Let me know if you’d like copy/text for the label to be localized or configurable, otherwise "Search" is used as requested.