### PR TITLE
FR par défaut (Deep/Pro) + UI française (barre latérale)

### DIFF
--- a/packages/ai/workflow/flow.ts
+++ b/packages/ai/workflow/flow.ts
@@ -121,7 +121,7 @@ export const runWorkflow = ({
     config = {},
     signal,
     webSearch = false,
-    showSuggestions = false,
+    showSuggestions= false,
     onFinish,
     customInstructions,
     gl,
@@ -152,9 +152,8 @@ export const runWorkflow = ({
         ...config,
     };
 
-    // Create typed event emitter withe the proper type
-    const events = createTypedEventEmitter__WORKFLOWEventSc7hema>({
-        steps: {},
+    // Create typed event emitter with the proper type
+    const events = createTypedEventEmitter<WorkflowEventSchema>({Š        steps: {},
         toolCalls: [],
         toolResults: [],
         answer: {

--- a/packages/ai/workflow/flow.ts
+++ b/packages/ai/workflow/flow.ts
@@ -152,8 +152,8 @@ export const runWorkflow = ({
         ...config,
     };
 
-    // Create typed event emitter with the proper type
-    const events = createTypedEventEmitter<WorkflowEventSchema>({
+    // Create typed event emitter withe the proper type
+    const events = createTypedEventEmitter__WORKFLOWEventSc7hema>({
         steps: {},
         toolCalls: [],
         toolResults: [],
@@ -226,7 +226,7 @@ export const runWorkflow = ({
         correctionTask,
         classificationTask,
         revisionDePrixTask,
-        nomenclatureDouanierTask,
+        nomenclatureDouaniereTask,
         smartPdfToExcelTask,
         suggestionsTask,
         quickSearchTask,

--- a/packages/ai/workflow/flow.ts
+++ b/packages/ai/workflow/flow.ts
@@ -175,7 +175,7 @@ export const runWorkflow = ({
     const frenchPrefMessage: CoreMessage = {
         role: 'system',
         content:
-            "Langue: francais par defaut. Reponds en francais. Si l'utilisateur c'exprime en anglais, reponds en anglais. Formate les dates et lieux au format fr-FR.",
+            "Langue: francais par defaut. Reponds en francais. Si l'utilisateur s'exprime en anglais, reponds en anglais. Formate les dates et lieux au format fr-FR.",
     };
 
     const localizedMessages =
@@ -183,16 +183,17 @@ export const runWorkflow = ({
             ? [frenchPrefMessage, ...(messages as any)]
             : (messages as any);
 
-    const context = createContext<WorkflowContextSchema>({
+    const context = createContext<WorkflowContextSchema>({{
         mcpConfig,
-        question,J        mode,
+        question,
+        mode,
         webSearch,
         search_queries: [],
         messages: localizedMessages,
         goals: [],
         queries: [],
         steps: [],
-        gl:,
+        gl,
         customInstructions,
         sources: [],
         summaries: [],
@@ -201,7 +202,7 @@ export const runWorkflow = ({
         threadItemId,
         showSuggestions,
         onFinish: onFinish as any,
-    });
+    }});
 
     // Use the typed builder
     const builder = new WorkflowBuilder(threadId, {

--- a/packages/ai/workflow/flow.ts
+++ b/packages/ai/workflow/flow.ts
@@ -175,7 +175,7 @@ export const runWorkflow = ({
     const frenchPrefMessage: CoreMessage = {
         role: 'system',
         content:
-            "Langue: francais par defaut. Reponds en francais. Si l'utilisateur s'exprime en anglais, reponds en anglais. Formate les dates et lieux au format fr-FR.",
+            "Langue: francais par defaut. Reponds en francais. Si l'utilisateur c'exprime en anglais, reponds en anglais. Formate les dates et lieux au format fr-FR.",
     };
 
     const localizedMessages =

--- a/packages/ai/workflow/flow.ts
+++ b/packages/ai/workflow/flow.ts
@@ -172,13 +172,24 @@ export const runWorkflow = ({
         status: 'PENDING',
     });
 
+    const frenchPrefMessage: CoreMessage = {
+        role: 'system',
+        content:
+            "Langue: français par défaut. Réponds en français. Si l’utilisateur s’exprime en anglais, réponds en anglais. Formate les dates et lieux au format fr-FR.",
+    };
+
+    const localizedMessages =
+        mode === ChatMode.Deep || mode === ChatMode.Pro
+            ? [frenchPrefMessage, ...(messages as any)]
+            : (messages as any);
+
     const context = createContext<WorkflowContextSchema>({
         mcpConfig,
         question,
         mode,
         webSearch,
         search_queries: [],
-        messages: messages as any,
+        messages: localizedMessages,
         goals: [],
         queries: [],
         steps: [],
@@ -215,7 +226,7 @@ export const runWorkflow = ({
         correctionTask,
         classificationTask,
         revisionDePrixTask,
-        nomenclatureDouaniereTask,
+        nomenclatureDouanierTask,
         smartPdfToExcelTask,
         suggestionsTask,
         quickSearchTask,

--- a/packages/ai/workflow/flow.ts
+++ b/packages/ai/workflow/flow.ts
@@ -153,7 +153,8 @@ export const runWorkflow = ({
     };
 
     // Create typed event emitter with the proper type
-    const events = createTypedEventEmitter<WorkflowEventSchema>({�        steps: {},
+    const events = createTypedEventEmitter<WorkflowEventSchema>({
+        steps: {},
         toolCalls: [],
         toolResults: [],
         answer: {
@@ -174,7 +175,7 @@ export const runWorkflow = ({
     const frenchPrefMessage: CoreMessage = {
         role: 'system',
         content:
-            "Langue: français par défaut. Réponds en français. Si l’utilisateur s’exprime en anglais, réponds en anglais. Formate les dates et lieux au format fr-FR.",
+            "Langue: francais par defaut. Reponds en francais. Si l'utilisateur s'exprime en anglais, reponds en anglais. Formate les dates et lieux au format fr-FR.",
     };
 
     const localizedMessages =
@@ -182,7 +183,7 @@ export const runWorkflow = ({
             ? [frenchPrefMessage, ...(messages as any)]
             : (messages as any);
 
-    const context = createContext<WorkflowContextSchema>({
+    const context = createContext<WorkflowContextSchema>({{
         mcpConfig,
         question,
         mode,
@@ -201,7 +202,7 @@ export const runWorkflow = ({
         threadItemId,
         showSuggestions,
         onFinish: onFinish as any,
-    });
+    }});
 
     // Use the typed builder
     const builder = new WorkflowBuilder(threadId, {
@@ -219,7 +220,7 @@ export const runWorkflow = ({
         reflectorTask,
         analysisTask,
         writerTask,
-        refineQueryTask,
+        refineQueryTask
         modeRoutingTask,
         completionTask,
         correctionTask,

--- a/packages/ai/workflow/flow.ts
+++ b/packages/ai/workflow/flow.ts
@@ -183,17 +183,16 @@ export const runWorkflow = ({
             ? [frenchPrefMessage, ...(messages as any)]
             : (messages as any);
 
-    const context = createContext<WorkflowContextSchema>({{
+    const context = createContext<WorkflowContextSchema>({
         mcpConfig,
-        question,
-        mode,
+        question,J        mode,
         webSearch,
         search_queries: [],
         messages: localizedMessages,
         goals: [],
         queries: [],
         steps: [],
-        gl,
+        gl:,
         customInstructions,
         sources: [],
         summaries: [],
@@ -202,7 +201,7 @@ export const runWorkflow = ({
         threadItemId,
         showSuggestions,
         onFinish: onFinish as any,
-    }});
+    });
 
     // Use the typed builder
     const builder = new WorkflowBuilder(threadId, {
@@ -220,7 +219,7 @@ export const runWorkflow = ({
         reflectorTask,
         analysisTask,
         writerTask,
-        refineQueryTask
+        refineQueryTask,
         modeRoutingTask,
         completionTask,
         correctionTask,

--- a/packages/common/components/thread/components/goals.tsx
+++ b/packages/common/components/thread/components/goals.tsx
@@ -13,15 +13,15 @@ import {
 import { memo, useEffect, useMemo } from 'react';
 const getTitle = (threadItem: ThreadItem) => {
     if (threadItem.mode === ChatMode.Deep) {
-        return 'Research';
+        return 'Recherche approfondie';
     }
     if ([ChatMode.DEEPSEEK_R1].includes(threadItem.mode)) {
-        return 'Thinking';
+        return 'Réflexion';
     }
     if (threadItem.mode === ChatMode.Pro) {
-        return 'Pro Search';
+        return 'Recherche Pro';
     }
-    return 'Steps';
+    return 'Étapes';
 };
 
 const getIcon = (threadItem: ThreadItem) => {
@@ -36,10 +36,10 @@ const getIcon = (threadItem: ThreadItem) => {
 
 const getNote = (threadItem: ThreadItem) => {
     if (threadItem.mode === ChatMode.Deep) {
-        return 'This process takes approximately 15 minutes. Please keep the tab open during this time.';
+        return 'Ce processus prend environ 15 minutes. Veuillez garder l’onglet ouvert pendant ce temps.';
     }
     if (threadItem.mode === ChatMode.Pro) {
-        return 'This process takes approximately 5 minutes. Please keep the tab open during this time.';
+        return 'Ce processus prend environ 5 minutes. Veuillez garder l’onglet ouvert pendant ce temps.';
     }
     return '';
 };
@@ -117,7 +117,7 @@ export const Steps = ({ steps, threadItem }: { steps: Step[]; threadItem: Thread
                 renderContent: () => (
                     <div className="flex w-full flex-1 flex-col px-2 py-4">
                         {steps.map((step, index) => (
-                            <StepRenderer key={index} step={step} />
+                            <StepRenderer key={index} step={step} mode={threadItem.mode} />
                         ))}
                     </div>
                 ),
@@ -136,7 +136,7 @@ export const Steps = ({ steps, threadItem }: { steps: Step[]; threadItem: Thread
             renderContent: () => (
                 <div className="flex w-full flex-1 flex-col px-2 py-4">
                     {steps.map((step, index) => (
-                        <StepRenderer key={index} step={step} />
+                        <StepRenderer key={index} step={step} mode={threadItem.mode} />
                     ))}
                     {/* {toolCallAndResults.map(({ toolCall, toolResult }) => (
                         <ToolStep toolCall={toolCall} toolResult={toolResult} />
@@ -186,7 +186,14 @@ export const Steps = ({ steps, threadItem }: { steps: Step[]; threadItem: Thread
                 <div className="flex-1" />
 
                 <Badge variant="default" size="sm">
-                    {stepCounts} {stepCounts === 1 ? 'Step' : 'Steps'}
+                    {stepCounts}{' '}
+                    {threadItem.mode === ChatMode.Deep || threadItem.mode === ChatMode.Pro
+                        ? stepCounts === 1
+                            ? 'Étape'
+                            : 'Étapes'
+                        : stepCounts === 1
+                          ? 'Step'
+                          : 'Steps'}
                 </Badge>
                 <IconChevronRight size={14} strokeWidth={2} />
             </div>

--- a/packages/common/components/thread/step-renderer.tsx
+++ b/packages/common/components/thread/step-renderer.tsx
@@ -5,11 +5,14 @@ import { IconSearch } from '@tabler/icons-react';
 import { motion } from 'framer-motion';
 import React from 'react';
 
+import { ChatMode } from '@repo/shared/config';
+
 export type StepRendererType = {
     step: Step;
+    mode?: ChatMode;
 };
 
-export const StepRenderer = ({ step }: StepRendererType) => {
+export const StepRenderer = ({ step, mode }: StepRendererType) => {
     console.log(step);
     const renderTextStep = () => {
         if (step?.text) {
@@ -43,7 +46,7 @@ export const StepRenderer = ({ step }: StepRendererType) => {
                                 spread={step.steps?.search?.status === 'COMPLETED' ? 0 : 2}
                                 className="text-xs"
                             >
-                                Searching
+                                {mode === ChatMode.Deep || mode === ChatMode.Pro ? 'Recherche en cours' : 'Searching'}
                             </TextShimmer>
                         </div>
 
@@ -84,7 +87,7 @@ export const StepRenderer = ({ step }: StepRendererType) => {
                             spread={step.steps?.read?.status === 'COMPLETED' ? 0 : 2}
                             className="text-xs"
                         >
-                            Reading
+                            {mode === ChatMode.Deep || mode === ChatMode.Pro ? 'Lecture' : 'Reading'}
                         </TextShimmer>
                     </div>
                     <SearchResultsList
@@ -114,7 +117,7 @@ export const StepRenderer = ({ step }: StepRendererType) => {
                             spread={step.steps?.reasoning?.status === 'COMPLETED' ? 0 : 2}
                             className="text-xs"
                         >
-                            Analyzing
+                            {mode === ChatMode.Deep || mode === ChatMode.Pro ? 'Analyse' : 'Analyzing'}
                         </TextShimmer>
                     </div>
                     <p className="text-muted-foreground text-sm">
@@ -147,7 +150,7 @@ export const StepRenderer = ({ step }: StepRendererType) => {
                             spread={step.steps?.wrapup?.status === 'COMPLETED' ? 0 : 2}
                             className="text-xs"
                         >
-                            Wrapping up
+                            {mode === ChatMode.Deep || mode === ChatMode.Pro ? 'Finalisation' : 'Wrapping up'}
                         </TextShimmer>
                     </div>
                     <p>{step.steps?.wrapup?.data || ''}</p>


### PR DESCRIPTION
# FR par défaut (Deep/Pro) + UI française barre latérale

Résumé
- Répondre en français par défaut pour les modes Deep et Pro, avec auto‑détection (si l’utilisateur s’exprime en anglais, répondre en anglais).
- Demander explicitement le formatage fr-FR pour les dates/lieux (niveau message système).
- Traduire les libellés de la barre latérale (Deep/Pro) :
  - Searching → Recherche en cours
  - Reading → Lecture
  - Analyzing → Analyse
  - Wrapping up → Finalisation
  - Titres : Deep → « Recherche approfondie », Pro → « Recherche Pro »
  - Notes d’aide sous le titre traduites
  - Badge Étape/Étapes (au lieu de Step/Steps)

Changements
- packages/ai/workflow/flow.ts
  - Injection d’un message système en tête de messages pour Deep/Pro : FR par défaut, auto‑détection, format fr‑FR.
- packages/common/components/thread/step-renderer.tsx
  - Libellés « Recherche en cours », « Lecture », « Analyse », « Finalisation » selon le mode (Deep/Pro).
- packages/common/components/thread/components/goals.tsx
  - Titres et notes traduits (Deep → Recherche approfondie, Pro → Recherche Pro).
  - Pluriel localisé sur le badge Étape/Étapes.

Non modifié
- Aucune modification de logique d’orchestration ni de routage des tâches.
- Aucune modification UI hors des libellés mentionnés.
- Les autres modes restent inchangés.

Vérification
- Lancer une recherche en mode Deep/Pro :
  - Réponse en français si la question est en français ; bascule en anglais si la question est en anglais.
  - Barre latérale (Search/Read/Reasoning/Wrapup) affichée en français.
  - Dates/lieux dans les réponses formatés en fr‑FR (côté modèle).


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/88d92368-35f3-4a9d-a478-24ddabb6c5d0/task/d6a5a5ab-e7bd-4836-a947-59b641f9dd85))