### PR TITLE
Fix Clerk OAuth final redirect to /chat; env config + admin steps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,10 @@ FREE_CREDITS_LIMIT_REQUESTS_AUTH=100
 FREE_CREDITS_LIMIT_REQUESTS_IP=10
 
 # App Configuration
-NEXT_PUBLIC_APP_URL=http://localhost:3000
+# Production app URL used for OAuth redirects
+NEXT_PUBLIC_APP_URL=https://hypergeant.vercel.app
+# Final path after sign-in/sign-up (relative path)
+NEXT_PUBLIC_AFTER_SIGN_IN_URL=/chat
 NEXT_PUBLIC_POSTHOG_KEY=your-posthog-key
 
 # PostHog Analytics (optional)

--- a/apps/web/README-AUTH-REDIRECTS.md
+++ b/apps/web/README-AUTH-REDIRECTS.md
@@ -1,0 +1,35 @@
+Auth Redirects — Clerk + OAuth
+
+Overview
+This app uses Clerk (@clerk/nextjs v6) with a custom sign‑in page at /sign-in and dedicated SSO callback pages at:
+- /sign-in/sso-callback
+- /sign-up/sso-callback
+
+During OAuth (Google, GitHub, Apple), the flow will briefly visit Clerk’s hosted domain (accounts.dev). The final redirect should land users on /chat in production at https://hypergeant.vercel.app.
+
+Clerk Dashboard Settings (Admin)
+Please apply these settings in the Clerk project used by production:
+
+1) Allowed origins
+- https://hypergeant.vercel.app
+
+2) Allowed redirect URLs
+- https://hypergeant.vercel.app/sign-in/sso-callback
+- https://hypergeant.vercel.app/sign-up/sso-callback
+
+Notes
+- HTTPS is recommended. Add http variants only if you explicitly test locally without a tunnel.
+- Do NOT enable the Clerk proxy. The team prefers accounts.dev to remain visible during the handshake.
+
+Environment variables in Vercel (Production)
+Set these variables in the Vercel project settings for the production environment:
+- NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_live_...
+- CLERK_SECRET_KEY=sk_live_...
+- NEXT_PUBLIC_APP_URL=https://hypergeant.vercel.app
+- NEXT_PUBLIC_AFTER_SIGN_IN_URL=/chat
+
+If you cannot obtain access to the current Clerk project, create a new Clerk project in an account you control and replace the Publishable/Secret keys in Vercel accordingly.
+
+What to expect after deploying
+- Clicking “Continuer avec Google” (or GitHub/Apple) may briefly go to accounts.dev for OAuth, then will return to https://hypergeant.vercel.app/chat.
+- Refreshing the page after sign‑in keeps the user authenticated on /chat, thanks to Clerk session cookies and afterSignInUrl configuration.

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -105,7 +105,7 @@ export default function ParentLayout({
             </head>
             <body>
                 {/* <PostHogProvider> */}
-                <ClerkProvider>
+                <ClerkProvider signInUrl="/sign-in" signUpUrl="/sign-up" afterSignInUrl="/chat" afterSignUpUrl="/chat">
                     <RootProvider>
                         {/* <ThemeProvider
             attribute="class"

--- a/apps/web/app/sign-in/page.tsx
+++ b/apps/web/app/sign-in/page.tsx
@@ -19,6 +19,7 @@ export default function OauthSignIn() {
     return (
         <div className="bg-secondary/95 fixed inset-0 z-[100] flex h-full w-full flex-col items-center justify-center gap-2 backdrop-blur-sm">
             <CustomSignIn
+                redirectUrl="/sign-in/sso-callback"
                 onClose={() => {
                     router.push('/chat');
                 }}

--- a/packages/common/components/sign-in.tsx
+++ b/packages/common/components/sign-in.tsx
@@ -14,6 +14,7 @@ export const CustomSignIn = ({
     onClose,
 }: CustomSignInProps) => {
     const [isLoading, setIsLoading] = useState<string | null>(null);
+    const afterSignInUrl = process.env.NEXT_PUBLIC_AFTER_SIGN_IN_URL || '/chat';
     const [email, setEmail] = useState('');
     const [error, setError] = useState('');
     const [verifying, setVerifying] = useState(false);
@@ -79,7 +80,7 @@ export const CustomSignIn = ({
             await signIn.authenticateWithRedirect({
                 strategy: 'oauth_google',
                 redirectUrl,
-                redirectUrlComplete: redirectUrl,
+                redirectUrlComplete: afterSignInUrl,
             });
         } catch (error) {
             console.error('Google authentication error:', error);
@@ -96,7 +97,7 @@ export const CustomSignIn = ({
             await signIn.authenticateWithRedirect({
                 strategy: 'oauth_github',
                 redirectUrl,
-                redirectUrlComplete: redirectUrl,
+                redirectUrlComplete: afterSignInUrl,
             });
         } catch (error) {
             console.error('GitHub authentication error:', error);
@@ -113,7 +114,7 @@ export const CustomSignIn = ({
             await signIn.authenticateWithRedirect({
                 strategy: 'oauth_apple',
                 redirectUrl,
-                redirectUrlComplete: redirectUrl,
+                redirectUrlComplete: afterSignInUrl,
             });
         } catch (error) {
             console.error('Apple authentication error:', error);


### PR DESCRIPTION
## Summary

Ensure OAuth (Google, GitHub, Apple) returns users to the app and lands on /chat in production. We keep Clerk's hosted domain during the OAuth handshake but guarantee the final redirect to our domain.

## Changes
- Set redirectUrlComplete to `/chat` (configurable via `NEXT_PUBLIC_AFTER_SIGN_IN_URL`) in the custom sign-in component for all OAuth strategies.
- Passed explicit `redirectUrl="/sign-in/sso-callback"` to the custom sign-in page.
- Configured `<ClerkProvider>` with `signInUrl`, `signUpUrl`, `afterSignInUrl`, `afterSignUpUrl` to keep fallbacks on our domain.
- Updated `.env.example` with `NEXT_PUBLIC_APP_URL` (production URL) and `NEXT_PUBLIC_AFTER_SIGN_IN_URL`.
- Added `apps/web/README-AUTH-REDIRECTS.md` for the admin to set Clerk allowed origins/redirect URLs and env keys.

## Why
Users were being sent to Clerk's hosted domain and not always returned to the intended page. This makes the final post-auth redirect deterministic and app-controlled without enabling Clerk proxy.

## Impact
- From https://hypergeant.vercel.app, clicking “Continuer avec Google/GitHub/Apple” will return to https://hypergeant.vercel.app/chat after OAuth.
- Refreshing on /chat after sign-in preserves authentication.
- Admins have clear, minimal steps to configure Clerk.

## Ops notes
Clerk Dashboard:
- Allowed origins:
  - https://hypergeant.vercel.app
- Allowed redirect URLs:
  - https://hypergeant.vercel.app/sign-in/sso-callback
  - https://hypergeant.vercel.app/sign-up/sso-callback
- Vercel env vars:
  - NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
  - CLERK_SECRET_KEY
  - NEXT_PUBLIC_APP_URL=https://hypergeant.vercel.app
  - NEXT_PUBLIC_AFTER_SIGN_IN_URL=/chat


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/88d92368-35f3-4a9d-a478-24ddabb6c5d0/task/4d9080f6-d87e-4737-bfd0-c174c0242e95))