### PR TITLE
Align Pro/Deep to Gemini 2.5 Flash; hide 'Gemini 2.5 Pro' option; add persisted fallback

### DIFF
--- a/packages/ai/workflow/tasks/analysis.ts
+++ b/packages/ai/workflow/tasks/analysis.ts
@@ -66,7 +66,7 @@ ${s}
 
         const text = await generateText({
             prompt,
-            model: ModelEnum.GEMINI_2_5_PRO,
+            model: ModelEnum.GEMINI_2_5_FLASH,
             messages: messages as any,
             signal,
             onReasoning: reasoning => {

--- a/packages/ai/workflow/tasks/planner.ts
+++ b/packages/ai/workflow/tasks/planner.ts
@@ -65,7 +65,7 @@ export const plannerTask = createTask<WorkflowEventSchema, WorkflowContextSchema
 
         const object = await generateObject({
             prompt,
-            model: ModelEnum.GEMINI_2_5_PRO,
+            model: ModelEnum.GEMINI_2_5_FLASH,
             schema: z.object({
                 reasoning: z.string(),
                 queries: z.array(z.string()),

--- a/packages/ai/workflow/tasks/pro-search.ts
+++ b/packages/ai/workflow/tasks/pro-search.ts
@@ -115,7 +115,7 @@ export const proSearchTask = createTask<WorkflowEventSchema, WorkflowContextSche
                     ${context?.get('gl')?.country ? `Vous êtes en ${context?.get('gl')?.country}\n\n` : ''}
                     
                     Générez une requête pour rechercher des informations sur le Web. Assurez-vous que la requête n’est pas trop large et qu’elle est spécifique, en privilégiant des informations récentes.`,
-                    model: ModelEnum.GEMINI_2_5_PRO,
+                    model: ModelEnum.GEMINI_2_5_FLASH,
                     messages,
                     schema: z.object({
                         query: z.string().min(1),
@@ -232,7 +232,7 @@ export const proSearchTask = createTask<WorkflowEventSchema, WorkflowContextSche
             try {
                 reasoning = await generateText({
                     prompt: getAnalysisPrompt(question, webPageContent),
-                    model: ModelEnum.GEMINI_2_5_PRO,
+                    model: ModelEnum.GEMINI_2_5_FLASH,
                     messages,
                     onReasoning: chunk => {
                         reasoningBuffer.add(chunk);

--- a/packages/ai/workflow/tasks/refine-query.ts
+++ b/packages/ai/workflow/tasks/refine-query.ts
@@ -55,7 +55,7 @@ export const refineQueryTask = createTask<WorkflowEventSchema, WorkflowContextSc
 
         const object = await generateObject({
             prompt,
-            model: ModelEnum.GEMINI_2_5_PRO,
+            model: ModelEnum.GEMINI_2_5_FLASH,
             schema: ClarificationResponseSchema,
             messages: messages as any,
             signal,

--- a/packages/ai/workflow/tasks/reflector.ts
+++ b/packages/ai/workflow/tasks/reflector.ts
@@ -94,7 +94,7 @@ Date actuelle : ${getHumanizedDate()}
 
         const object = await generateObject({
             prompt,
-            model: ModelEnum.GEMINI_2_5_PRO,
+            model: ModelEnum.GEMINI_2_5_FLASH,
             schema: z.object({
                 reasoning: z.string(),
                 queries: z.array(z.string()).optional().nullable(),

--- a/packages/ai/workflow/tasks/web-search.ts
+++ b/packages/ai/workflow/tasks/web-search.ts
@@ -119,7 +119,7 @@ Citations et références:
       `;
 
         const summary = await generateText({
-            model: ModelEnum.GEMINI_2_5_PRO,
+            model: ModelEnum.GEMINI_2_5_FLASH,
             prompt,
         });
 

--- a/packages/ai/workflow/tasks/writer.ts
+++ b/packages/ai/workflow/tasks/writer.ts
@@ -92,7 +92,7 @@ Votre rapport doit démontrer une expertise du sujet tout en restant accessible 
 
         const answer = await generateText({
             prompt,
-            model: ModelEnum.GEMINI_2_5_PRO,
+            model: ModelEnum.GEMINI_2_5_FLASH,
             messages,
             signal,
             onChunk: (chunk, fullText) => {

--- a/packages/common/components/chat-input/animated-input.tsx
+++ b/packages/common/components/chat-input/animated-input.tsx
@@ -144,12 +144,13 @@ export const AnimatedChatInput = ({
         // Active model
         {
             id: ChatMode.GEMINI_2_5_FLASH,
-            name: 'Flash 2.5',
+            name: 'Gemini 2.5 Flash',
             icon: ModelIcons.GEMINI,
             creditCost: CHAT_MODE_CREDIT_COSTS[ChatMode.GEMINI_2_5_FLASH],
             isAuthRequired: ChatModeConfig[ChatMode.GEMINI_2_5_FLASH].isAuthRequired,
             category: 'standard',
         },
+        /* Masqué à la demande (Zen): garder le code mais ne pas afficher cette option.
         {
             id: ChatMode.GEMINI_2_5_PRO,
             name: 'Gemini 2.5 Pro',
@@ -158,6 +159,7 @@ export const AnimatedChatInput = ({
             isAuthRequired: ChatModeConfig[ChatMode.GEMINI_2_5_PRO].isAuthRequired,
             category: 'standard',
         },
+        */
         // Commented models (will be filtered out below)
         // {
         //     id: ChatMode.LLAMA_4_SCOUT,

--- a/packages/common/store/chat.store.ts
+++ b/packages/common/store/chat.store.ts
@@ -41,7 +41,12 @@ const loadInitialData = async () => {
               showSuggestions: true,
               chatMode: ChatMode.GEMINI_2_5_FLASH,
           };
-    const chatMode = config.chatMode || ChatMode.GEMINI_2_5_FLASH;
+    // Fallback: Masqué à la demande (Zen) — si une ancienne config contient 'gemini-2.5-pro', basculer silencieusement sur 'gemini-2.5-flash'
+    const persistedChatMode = config.chatMode;
+    const chatMode =
+        persistedChatMode === ChatMode.GEMINI_2_5_PRO
+            ? ChatMode.GEMINI_2_5_FLASH
+            : persistedChatMode || ChatMode.GEMINI_2_5_FLASH;
     const useWebSearch = typeof config.useWebSearch === 'boolean' ? config.useWebSearch : false;
     const customInstructions = config.customInstructions || '';
 
@@ -521,9 +526,11 @@ export const useChatStore = create(
         },
 
         setChatMode: (chatMode: ChatMode) => {
-            localStorage.setItem(CONFIG_KEY, JSON.stringify({ chatMode }));
+            // Fallback: Masqué à la demande (Zen) — rediriger toute sélection 'gemini-2.5-pro' vers 'gemini-2.5-flash'
+            const safeChatMode = chatMode === ChatMode.GEMINI_2_5_PRO ? ChatMode.GEMINI_2_5_FLASH : chatMode;
+            localStorage.setItem(CONFIG_KEY, JSON.stringify({ chatMode: safeChatMode }));
             set(state => {
-                state.chatMode = chatMode;
+                state.chatMode = safeChatMode;
             });
         },
 


### PR DESCRIPTION
Summary
- Align Pro and Deep modes to use gemini-2.5-flash consistently, avoiding model drift and ensuring a single, reliable default for advanced workflows.
- Hide the "Gemini 2.5 Pro" option in the prompt UI to reduce user confusion while keeping the provider code intact for future use.
- Add a silent fallback to map any persisted selection of 'gemini-2.5-pro' to 'gemini-2.5-flash' to prevent load-time errors.

Changes
- Workflow model routing (Pro/Deep):
  - analysis.ts, planner.ts, pro-search.ts, refine-query.ts, reflector.ts, web-search.ts, writer.ts → switch ModelEnum.GEMINI_2_5_PRO → ModelEnum.GEMINI_2_5_FLASH.
- UI dropdown (Ai_Prompt):
  - packages/common/components/chat-input/animated-input.tsx → comment out "Gemini 2.5 Pro" option with note:
    // Masqué à la demande (Zen): garder le code mais ne pas afficher cette option.
  - Harmonize label: "Flash 2.5" → "Gemini 2.5 Flash".
- Persisted config fallback:
  - packages/common/store/chat.store.ts →
    - loadInitialData: map persisted ChatMode.GEMINI_2_5_PRO → ChatMode.GEMINI_2_5_FLASH.
    - setChatMode: redirect selection of PRO → FLASH before persisting.

Nature of changes
- Enhancement/routing change + minor UI adjustment + resilience for persisted settings.

Impact
- Pro and Deep workloads now use gemini-2.5-flash (verifiable via workflow modelId usage).
- UI no longer shows "Gemini 2.5 Pro" in the model dropdown; code remains in place and commented.
- Any user configs pointing to 'gemini-2.5-pro' seamlessly fall back to 'gemini-2.5-flash'.
- Other models/providers unaffected; no provider code removed.

Why
- Product decision to standardize on gemini-2.5-flash for Pro/Deep while removing the Pro choice from the UI to simplify the experience and avoid misconfigurations.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/42a73b29-fae3-41c7-a4ed-b5e60679cb02/task/712f8a5b-bc6c-4e8c-b87d-b1c28db808b8))