### PR TITLE
Show a static grid+radial background when no thread so the centered c…

### DIFF
--- a/packages/common/components/chat-input/animated-input.tsx
+++ b/packages/common/components/chat-input/animated-input.tsx
@@ -8,7 +8,7 @@ import {
 } from '@repo/common/components';
 import { useImageAttachment } from '@repo/common/hooks';
 import { CHAT_MODE_CREDIT_COSTS, ChatMode, ChatModeConfig, getChatModeName } from '@repo/shared/config';
-import { cn, Flex, AI_Prompt, ModelIcons, useToast } from '@repo/ui';
+import { cn, Flex, AI_Prompt, ModelIcons, useToast, GridGradientBackground } from '@repo/ui';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useParams, usePathname, useRouter } from 'next/navigation';
 import React, { useEffect } from 'react';
@@ -382,6 +382,7 @@ export const AnimatedChatInput = ({
                     : 'absolute inset-0 flex h-full w-full flex-col items-center justify-center'
             )}
         >
+            {!currentThreadId && <GridGradientBackground side="left" />}
             <div
                 className={cn(
                     'mx-auto flex w-full max-w-3xl flex-col items-start',

--- a/packages/common/components/chat-input/input.tsx
+++ b/packages/common/components/chat-input/input.tsx
@@ -7,7 +7,7 @@ import {
 } from '@repo/common/components';
 import { useImageAttachment } from '@repo/common/hooks';
 import { ChatModeConfig } from '@repo/shared/config';
-import { cn, Flex } from '@repo/ui';
+import { cn, Flex, GridGradientBackground } from '@repo/ui';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useParams, usePathname, useRouter } from 'next/navigation';
 import React, { useEffect } from 'react';
@@ -234,6 +234,7 @@ export const ChatInput = ({
                     : 'absolute inset-0 flex h-full w-full flex-col items-center justify-center'
             )}
         >
+            {!currentThreadId && <GridGradientBackground side="left" />}
             <div
                 className={cn(
                     'mx-auto flex w-full max-w-3xl flex-col items-start',

--- a/packages/ui/src/components/grid-gradient-background.tsx
+++ b/packages/ui/src/components/grid-gradient-background.tsx
@@ -1,0 +1,44 @@
+'use client';
+import React from 'react';
+import { cn } from '../lib/utils';
+
+type GridGradientBackgroundProps = {
+  side?: 'left' | 'right';
+  className?: string;
+  style?: React.CSSProperties;
+};
+
+export function GridGradientBackground({ side = 'left', className, style }: GridGradientBackgroundProps) {
+  const radialAt = side === 'right' ? '100% 200px' : '0% 200px';
+
+  return (
+    <>
+      {/* Clair */}
+      <div
+        className={cn('absolute inset-0 block dark:hidden', className)}
+        style={{
+          backgroundImage: `
+            linear-gradient(to right, #eaeaea 1px, transparent 1px),
+            linear-gradient(to bottom, #eaeaea 1px, transparent 1px),
+            radial-gradient(circle 800px at ${radialAt}, #d5c5ff, transparent)
+          `,
+          backgroundSize: '96px 64px, 96px 64px, 100% 100%',
+          ...style,
+        }}
+      />
+      {/* Sombre */}
+      <div
+        className={cn('absolute inset-0 hidden dark:block', className)}
+        style={{
+          backgroundImage: `
+            linear-gradient(to right, rgba(255,255,255,0.06) 1px, transparent 1px),
+            linear-gradient(to bottom, rgba(255,255,255,0.06) 1px, transparent 1px),
+            radial-gradient(circle 800px at ${radialAt}, rgba(139,92,246,0.25), transparent)
+          `,
+          backgroundSize: '96px 64px, 96px 64px, 100% 100%',
+          ...style,
+        }}
+      />
+    </>
+  );
+}

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -42,4 +42,6 @@ export * from './animated-ai-input';
 export * from './shine-border';
 
 // Export specific components that are needed
+export * from './grid-gradient-background';
+
 export { AI_Prompt, ModelIcons } from './animated-ai-input';


### PR DESCRIPTION
…hat feels grounded; export component from @repo/ui and integrate in both animated and editor inputs. Background disappears once a thread is created without touching draft persistence or z-index/pointer-events.