### PR TITLE
feat(ui): CircularGallery under chat input with first-visit/new-thread visibility

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,6 +19,7 @@
     "framer-motion": "^11.14.3",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.468.0",
+    "ogl": "^1.0.7",
     "tailwind-merge": "^2.0.0",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/packages/ui/src/components/circular-gallery.tsx
+++ b/packages/ui/src/components/circular-gallery.tsx
@@ -24,7 +24,7 @@ const DEFAULTS = {
   font: "bold 30px DM Sans",
 };
 
-export const CircularGallery: React.FC<CircularGalleryProps> = ({
+const CircularGallery: React.FC<CircularGalleryProps> = ({
   items = DEFAULT_ITEMS,
   bend = DEFAULTS.bend,
   textColor = DEFAULTS.textColor,

--- a/packages/ui/src/components/circular-gallery.tsx
+++ b/packages/ui/src/components/circular-gallery.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import React, { useEffect, useRef } from "react";
+
+type Item = { image: string; text: string };
+
+export type CircularGalleryProps = {
+  items?: Item[];
+  bend?: number;
+  textColor?: string;
+  borderRadius?: number;
+  font?: string;
+};
+
+const DEFAULT_ITEMS: Item[] = Array.from({ length: 10 }).map((_, i) => ({
+  image: `https://picsum.photos/seed/cg_${i}/512/512`,
+  text: `Item ${i + 1}`,
+}));
+
+const DEFAULTS = {
+  bend: 3,
+  textColor: "#ffffff",
+  borderRadius: 0.05,
+  font: "bold 30px DM Sans",
+};
+
+export const CircularGallery: React.FC<CircularGalleryProps> = ({
+  items = DEFAULT_ITEMS,
+  bend = DEFAULTS.bend,
+  textColor = DEFAULTS.textColor,
+  borderRadius = DEFAULTS.borderRadius,
+  font = DEFAULTS.font,
+}) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    let destroyed = false;
+    let gl: WebGLRenderingContext | WebGL2RenderingContext | null = null;
+    let renderer: any = null;
+    let camera: any = null;
+    let scene: any = null;
+    let group: any = null;
+    let targetSpeed = 0;
+    let rotation = 0;
+
+    let handleResize: (() => void) | null = null;
+    let onMouseMove: ((e: MouseEvent) => void) | null = null;
+    let onWheel: ((e: WheelEvent) => void) | null = null;
+    let onTouchMove: ((e: TouchEvent) => void) | null = null;
+
+    const el = containerRef.current;
+
+    (async () => {
+      const OGL: any = await import("ogl");
+      if (destroyed) return;
+
+      renderer = new OGL.Renderer({ alpha: true, antialias: true, powerPreference: "high-performance" });
+      gl = renderer.gl;
+      if (!gl) return;
+      gl.clearColor(0, 0, 0, 0);
+      el!.appendChild(renderer.domElement);
+
+      camera = new OGL.Camera(gl, { fov: 35 });
+      camera.position.set(0, 0, 7);
+      scene = new OGL.Transform();
+      group = new OGL.Transform();
+      scene.addChild(group);
+
+      const createRoundedPlaneProgram = () => {
+        const vertex = /* glsl */ `
+          attribute vec2 uv;
+          attribute vec3 position;
+          uniform mat4 modelViewMatrix;
+          uniform mat4 projectionMatrix;
+          varying vec2 vUv;
+          void main() {
+            vUv = uv;
+            gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+          }
+        `;
+        const fragment = /* glsl */ `
+          precision highp float;
+          uniform sampler2D uTexture;
+          uniform float uOpacity;
+          uniform float uRadius;
+          varying vec2 vUv;
+
+          float roundedBoxSDF(vec2 p, vec2 b, float r){
+            vec2 q = abs(p) - b + vec2(r);
+            return length(max(q, 0.0)) - r;
+          }
+
+          void main(){
+            vec2 p = (vUv - 0.5) * 2.0;
+            float sdf = roundedBoxSDF(p, vec2(1.0), uRadius);
+            if (sdf > 0.0) discard;
+            vec4 color = texture2D(uTexture, vUv);
+            gl_FragColor = vec4(color.rgb, color.a * uOpacity);
+          }
+        `;
+        return { vertex, fragment };
+      };
+
+      const { vertex, fragment } = createRoundedPlaneProgram();
+
+      const makeTexture = (url: string) => {
+        const texture = new OGL.Texture(gl);
+        const img = new Image();
+        img.crossOrigin = "anonymous";
+        img.onload = () => {
+          texture.image = img;
+        };
+        img.src = url;
+        return texture;
+      };
+
+      const planes: any[] = [];
+      const geo = new OGL.Plane(gl, { width: 1.2, height: 1.2, widthSegments: 1, heightSegments: 1 });
+
+      const programCache: Record<string, any> = {};
+      const getProgram = () => {
+        if (!programCache.base) {
+          programCache.base = new OGL.Program(gl, {
+            vertex,
+            fragment,
+            transparent: true,
+            uniforms: {
+              uTexture: { value: null },
+              uOpacity: { value: 1 },
+              uRadius: { value: Math.max(0.0, Math.min(0.49, borderRadius)) },
+            },
+          });
+        }
+        return programCache.base;
+      };
+
+      const count = Math.max(6, items.length);
+      const radius = 3.2;
+
+      for (let i = 0; i < count; i++) {
+        const item = items[i % items.length];
+        const texture = makeTexture(item.image);
+        const program = getProgram();
+        const mesh = new OGL.Mesh(gl, { geometry: geo, program });
+        mesh.program = program;
+        mesh.program.uniforms.uTexture.value = texture;
+        const angle = (i / count) * Math.PI * 2;
+        mesh.position.set(
+          Math.cos(angle) * radius,
+          Math.sin(angle) * (radius * 0.45),
+          0
+        );
+        mesh.rotation.z = angle + Math.PI * 0.5;
+        mesh.setParent(group);
+        planes.push(mesh);
+      }
+
+      function resize() {
+        const width = el!.clientWidth || 300;
+        const height = el!.clientHeight || 300;
+        renderer.setSize(width, height);
+        camera.perspective({ aspect: width / height });
+        const scale = Math.min(width, height) / 600
+        planes.forEach((m) => {
+          m.scale.set(scale, scale, 1);
+        });
+      }
+
+      handleResize = resize;
+      window.addEventListener("resize", handleResize);
+      resize();
+
+      onMouseMove = (e: MouseEvent) => {
+        const rect = el!.getBoundingClientRect();
+        const x = (e.clientX - rect.left) / rect.width - 0.5;
+        targetSpeed = x * 0.02 * bend;
+      };
+      el!.addEventListener("mousemove", onMouseMove);
+
+      onTouchMove = (e: TouchEvent) => {
+        const t = e.touches[0];
+        if (!t) return;
+        const rect = el!.getBoundingClientRect();
+        const x = (t.clientX - rect.left) / rect.width - 0.5;
+        targetSpeed = x * 0.02 * bend;
+      };
+      el!.addEventListener("touchmove", onTouchMove, { passive: true });
+
+      onWheel = (e: WheelEvent) => {
+        targetSpeed += (e.deltaY > 0 ? -1 : 1) * 0.01;
+      };
+      el!.addEventListener("wheel", onWheel, { passive: true });
+
+      const tick = () => {
+        if (destroyed) return;
+        rotation += targetSpeed;
+        targetSpeed *= 0.95;
+        group.rotation.z = rotation;
+        renderer.render({ scene, camera });
+        rafRef.current = requestAnimationFrame(tick);
+      };
+
+      tick();
+    })();
+
+    return () => {
+      destroyed = true;
+
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+
+      try {
+        if (onMouseMove) containerRef.current?.removeEventListener("mousemove", onMouseMove as any);
+        if (onTouchMove) containerRef.current?.removeEventListener("touchmove", onTouchMove as any);
+        if (onWheel) containerRef.current?.removeEventListener("wheel", onWheel as any);
+        if (handleResize) window.removeEventListener("resize", handleResize);
+      } catch {}
+
+      try {
+        const canvas = containerRef.current?.querySelector("canvas");
+        if (canvas && canvas.parentElement) canvas.parentElement.removeChild(canvas);
+      } catch {}
+
+      try {
+        const loseCtx: any = (gl as any) && (gl as any).getExtension && (gl as any).getExtension("WEBGL_lose_context");
+        if (loseCtx && loseCtx.loseContext) loseCtx.loseContext();
+      } catch {}
+    };
+  }, [items, bend, textColor, borderRadius, font]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-full w-full"
+      style={{ position: "relative", overflow: "hidden" }}
+      aria-label="Circular Gallery"
+    />
+  );
+};
+
+export const Component = CircularGallery;
+export { CircularGallery };

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -43,5 +43,6 @@ export * from './shine-border';
 
 // Export specific components that are needed
 export * from './grid-gradient-background';
+export * from './circular-gallery';
 
 export { AI_Prompt, ModelIcons } from './animated-ai-input';


### PR DESCRIPTION
## Summary

Introduce a transparent, responsive CircularGallery beneath the chat input to provide an engaging, instructive visual for first-time and new-thread experiences. The gallery respects container width (max-w-3xl), scales smoothly across iPad and desktop, and is hidden as soon as a thread’s first message is sent.

## Changes
- feat(ui): add ogl-powered CircularGallery component with robust cleanup and transparent canvas.
- feat(common): integrate CircularGallery under AnimatedChatInput’s AI_Prompt with conditional visibility and responsive fixed-height wrapper.
- chore(ui): export new component from @repo/ui and add dependency on `ogl`.

## Visibility rules
- First visit to /chat in a fresh browser (no `cg_seen` in localStorage): show once and set `cg_seen='1'`.
- On /chat/[threadId] when the current thread has 0 messages: show the gallery.
- On sending the first message in any thread: hide the gallery immediately and keep it hidden for that thread thereafter.

## Implementation notes
- Placed directly below AI_Prompt, within the same container (mx-auto w-full max-w-3xl) to ensure it never exceeds input width.
- Wrapper heights: h-[260px] md:h-[340px] lg:h-[380px]; rounded and overflow-hidden.
- ogl scene uses alpha (transparent) background, rAF loop, and cleans up listeners, canvas, and GL context on unmount.

## Why
- Creates a compelling onboarding moment on the landing page.
- Provides visual guidance for empty threads without cluttering ongoing conversations.
- Maintains layout integrity and performance with careful sizing and cleanup.

## Screens/Areas affected
- /chat (landing)
- /chat/[threadId] (new empty threads)

## Risks & mitigations
- WebGL resource leaks: mitigated via thorough cleanup (cancelAnimationFrame, removeEventListeners, remove canvas, WEBGL_lose_context).
- Layout overflow: constrained within the existing input container (max-w-3xl) with responsive fixed heights.

## Checklist
- [x] Component exports available via `@repo/ui`.
- [x] Added `ogl` dependency to `@repo/ui`.
- [x] Visibility logic via localStorage and thread message count.
- [x] Example prompts hidden while gallery is visible to avoid clutter.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/55035c5b-4ce1-47c9-b2de-5172f053898f/task/8da7f86b-eb6d-4519-8f88-c50df061b98d))