### PR TITLE
Gemini 2.5 Flash: Exemples de prompts sous l’éditeur + transition

### DIFF
--- a/packages/common/components/chat-input/input.tsx
+++ b/packages/common/components/chat-input/input.tsx
@@ -6,7 +6,7 @@ import {
     MessagesRemainingBadge,
 } from '@repo/common/components';
 import { useImageAttachment } from '@repo/common/hooks';
-import { ChatModeConfig } from '@repo/shared/config';
+import { ChatModeConfig, ChatMode } from '@repo/shared/config';
 import { cn, Flex, GridGradientBackground } from '@repo/ui';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useParams, usePathname, useRouter } from 'next/navigation';
@@ -159,6 +159,20 @@ export const ChatInput = ({
                                             className="px-3 pt-3"
                                         />
                                     </Flex>
+                                    <AnimatePresence initial={false}>
+                                        {chatMode === ChatMode.GEMINI_2_5_FLASH && (
+                                            <motion.div
+                                                key="example-prompts"
+                                                initial={{ opacity: 0, y: 8 }}
+                                                animate={{ opacity: 1, y: 0 }}
+                                                exit={{ opacity: 0, y: 8 }}
+                                                transition={{ duration: 0.3, ease: 'easeOut' }}
+                                                className="mt-2"
+                                            >
+                                                <ExamplePrompts />
+                                            </motion.div>
+                                        )}
+                                    </AnimatePresence>
 
                                     <Flex
                                         className="border-border w-full gap-0 border-t border-dashed px-2 py-2"
@@ -262,7 +276,7 @@ export const ChatInput = ({
                     )}
 
                     {renderChatBottom()}
-                    {!currentThreadId && showGreeting && <ExamplePrompts />}
+                    {!currentThreadId && false}
 
                     {/* <ChatFooter /> */}
                 </Flex>

--- a/packages/common/components/exmaple-prompts.tsx
+++ b/packages/common/components/exmaple-prompts.tsx
@@ -71,7 +71,6 @@ const categoryIcons = {
 export const ExamplePrompts = () => {
     const editor: Editor | undefined = useChatStore(state => state.editor);
     const handleCategoryClick = (category: keyof typeof examplePrompts) => {
-        console.log('editor', editor);
         if (!editor) return;
         const randomPrompt = getRandomPrompt(category);
         editor.commands.clearContent();


### PR DESCRIPTION
## Résumé (pourquoi)
- Accélérer le démarrage des conversations avec Gemini 2.5 Flash grâce à des exemples contextualisés directement sous l’éditeur.
- Fluidifier l’expérience lors du changement de modèle via une transition discrète et professionnelle.
- Éviter toute confusion en affichant ces suggestions uniquement quand le modèle actif est « gemini-2.5-flash ».

## Changements principaux
- ChatInput (TipTap): rendu conditionnel du composant d’exemples juste sous l’éditeur lorsque `chatMode === 'gemini-2.5-flash'`.
- Transition Framer Motion: `AnimatePresence` + `motion.div` avec `initial={{ opacity: 0, y: 8 }}`, `animate={{ opacity: 1, y: 0 }}`, `exit={{ opacity: 0, y: 8 }}`, `transition={{ duration: 0.3, ease: 'easeOut' }}`.
- Suppression de l’ancien rendu `<ExamplePrompts />` placé sous le greeting dans ChatInput pour éviter les doublons hors condition.
- Nettoyage: retrait d’un `console.log` inutile dans `exmaple-prompts.tsx`.

## Comportement / critères d’acceptation
- Quand `chatMode === 'gemini-2.5-flash'`, le bloc d’exemples apparaît immédiatement sous l’éditeur avec un fade + léger slide up (~300ms).
- En changeant vers un autre modèle, le bloc disparaît complètement avec la même transition.
- Clic sur une catégorie: insertion d’un prompt aléatoire via `editor.commands.clearContent()` puis `editor.commands.insertContent(randomPrompt)`; l’utilisateur peut modifier librement le texte dans l’éditeur.
- Robustesse: si l’éditeur n’est pas encore initialisé, le composant retourne `null` (aucune erreur, pas de capture de focus quand caché).

## Comment tester
1. Ouvrir l’input (TipTap) et sélectionner le modèle "Gemini 2.5 Flash" dans le menu des modèles.
2. Vérifier que le bloc d’exemples s’affiche sous l’éditeur avec la transition (fade + slide up).
3. Basculer vers un autre modèle (ex: Correction): le bloc disparaît proprement.
4. Revenir sur "Gemini 2.5 Flash": le bloc réapparaît avec la même transition.
5. Cliquer sur différentes catégories: le contenu de l’éditeur est remplacé par un exemple aléatoire propre à la catégorie; vous pouvez ensuite modifier librement le texte.

## Notes d’intégration
- Le fichier `exmaple-prompts.tsx` conserve son nom (coquille) pour limiter l’ampleur des diffs.
- Ciblage exact du modèle: `'gemini-2.5-flash'` (via l’enum `ChatMode.GEMINI_2_5_FLASH`).
- Cette intégration cible `ChatInput` (TipTap). `AnimatedChatInput` (basé sur `AI_Prompt`) n’est pas modifié dans cette PR.

## Impact
- Portée UI uniquement, aucune nouvelle dépendance. Framer Motion est déjà présent.
- Pas de warning console attendu (SSR/CSR safe); les actions sont neutralisées si l’éditeur n’est pas prêt.

## Checklist
- [x] Affichage conditionnel pour `gemini-2.5-flash` uniquement.
- [x] Transition (fade + slide up) 300ms easeOut à l’apparition/disparition.
- [x] Clic → insertion aléatoire par catégorie, remplacement du contenu existant.
- [x] Pas de renommage de fichier, pas de breaking changes.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/55035c5b-4ce1-47c9-b2de-5172f053898f/task/c256f4f8-c397-429c-9a1d-a51775ff4be2))