### PR TITLE
fix(web): unblock Vercel build by using background-color in globals.css

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -225,7 +225,7 @@ mark.prompt-highlight {
     /* Tailwind doesn't support very specific pixel values like -7px */
     height: 20px;
     width: 20px;
-    background: hsl(var(--muted));
+    background-color: hsl(var(--muted));
     border-bottom-right-radius: 15px;
 }
 
@@ -237,7 +237,7 @@ mark.prompt-highlight {
     left: -10px;
     width: 10px;
     height: 20px;
-    background: hsl(var(--background));
+    background-color: hsl(var(--background));
     border-bottom-right-radius: 10px;
 }
 


### PR DESCRIPTION
## Summary
Fix Vercel/Next.js build failure caused by CSS parsing of `hsl(var(--…))` when used with the `background` shorthand inside pseudo-elements.

## Changes
- apps/web/app/globals.css: replace `background: hsl(var(--muted))` and `background: hsl(var(--background))` with the explicit `background-color: …` in `.greeting-bubble::before` and `.greeting-bubble::after`.

## Why
On Vercel, the build failed during CSS processing with:

```
SyntaxError: Unexpected token, expected "," (228:2)
Import trace:
./app/globals.css.webpack[...]!postcss-loader!./app/globals.css
```

This appears to be a parsing edge case in the toolchain (sucrase + css/postcss loader) when the `background` shorthand holds an `hsl(var(--…))` value. Using `background-color` avoids that path while preserving the same styling.

## Impact
- Type: fix
- Effect: Unblocks production build; no visual changes.
- Scope: web app only.

## Notes
- Non-blocking warnings remain (Browserslist DB update, Sentry auth token missing) and can be addressed separately.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/572b0dde-84af-11f0-a94e-3eef481a796b/task/67bfc28c-f2d1-48f5-9f57-bf1df7a693f7))