### PR TITLE
Enable PDF attachments for Gemini Flash and Smart PDF → Excel with server-side extraction and prompt injection

### DIFF
--- a/apps/web/app/api/pdf/extract/route.ts
+++ b/apps/web/app/api/pdf/extract/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest } from 'next/server';
+import pdfParse from 'pdf-parse';
+
+export const runtime = 'nodejs';
+
+export async function POST(request: NextRequest) {
+    try {
+        const formData = await request.formData();
+        const files = formData.getAll('file') as File[];
+
+        if (!files || files.length === 0) {
+            return new Response(
+                JSON.stringify({ error: 'No files provided' }),
+                { status: 400, headers: { 'Content-Type': 'application/json' } }
+            );
+        }
+
+        const MAX_FILE_SIZE_PDF = 20 * 1024 * 1024; // 20MB per file
+        const texts: { filename?: string; text: string }[] = [];
+
+        for (const file of files) {
+            if (file.type !== 'application/pdf') {
+                return new Response(
+                    JSON.stringify({ error: 'Only PDF files are supported' }),
+                    { status: 400, headers: { 'Content-Type': 'application/json' } }
+                );
+            }
+
+            if (file.size > MAX_FILE_SIZE_PDF) {
+                return new Response(
+                    JSON.stringify({ error: 'PDF exceeds 20MB limit', filename: (file as any).name }),
+                    { status: 413, headers: { 'Content-Type': 'application/json' } }
+                );
+            }
+
+            const buffer = Buffer.from(await file.arrayBuffer());
+
+            const controller = new AbortController();
+            const timeout = setTimeout(() => controller.abort(), 15000);
+
+            try {
+                const data = await pdfParse(buffer);
+                const rawText = (data?.text || '').trim();
+                texts.push({ filename: (file as any).name, text: rawText });
+            } catch (err: any) {
+                if (controller.signal.aborted) {
+                    return new Response(
+                        JSON.stringify({ error: 'Extraction timed out' }),
+                        { status: 504, headers: { 'Content-Type': 'application/json' } }
+                    );
+                }
+                return new Response(
+                    JSON.stringify({ error: err?.message || 'Failed to parse PDF' }),
+                    { status: 500, headers: { 'Content-Type': 'application/json' } }
+                );
+            } finally {
+                clearTimeout(timeout);
+            }
+        }
+
+        // Combine and lightly truncate to keep payloads reasonable
+        const combined = texts.map(t => `${t.filename ? `[${t.filename}]\n` : ''}${t.text}`).join('\n\n');
+        const MAX_OUTPUT = 200_000; // char limit
+        const combinedText = combined.length > MAX_OUTPUT ? combined.slice(0, MAX_OUTPUT) + '\n... [truncated]' : combined;
+
+        return new Response(
+            JSON.stringify({ texts, combinedText }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+    } catch (error: any) {
+        return new Response(
+            JSON.stringify({ error: error?.message || 'Unexpected server error' }),
+            { status: 500, headers: { 'Content-Type': 'application/json' } }
+        );
+    }
+}

--- a/packages/common/components/chat-input/image-attachment.tsx
+++ b/packages/common/components/chat-input/image-attachment.tsx
@@ -10,20 +10,29 @@ export const ImageAttachment = () => {
 
     if (!attachments || attachments.length === 0) return null;
 
+    const isPdf = (att: { base64?: string; file?: File }) =>
+        att?.file?.type === 'application/pdf' || (att?.base64?.startsWith?.('data:application/pdf') ?? false);
+
     return (
         <Flex className="pl-2 pr-2 pt-2 md:pl-3" gap="sm" direction="col">
             <div className="text-xs text-muted-foreground">{attachments.length} image{attachments.length > 1 ? 's' : ''} attached</div>
             <div className="flex flex-wrap gap-2">
                 {attachments.map((att, idx) => (
-                    <div key={idx} className="relative h-[40px] w-[40px] rounded-lg border border-black/10 shadow-sm dark:border-white/10">
-                        {att.base64 && (
-                            <Image
-                                src={att.base64}
-                                alt={`uploaded image ${idx + 1}`}
-                                className="h-full w-full overflow-hidden rounded-lg object-cover"
-                                width={40}
-                                height={40}
-                            />
+                    <div key={idx} className="relative h-[40px] w-[40px] rounded-lg border border-black/10 shadow-sm dark:border-white/10" title={att?.file?.name || undefined}>
+                        {isPdf(att) ? (
+                            <div className="flex h-full w-full items-center justify-center rounded-lg bg-muted text-[10px] font-medium text-foreground/80">
+                                PDF
+                            </div>
+                        ) : (
+                            att.base64 && (
+                                <Image
+                                    src={att.base64}
+                                    alt={`uploaded image ${idx + 1}`}
+                                    className="h-full w-full overflow-hidden rounded-lg object-cover"
+                                    width={40}
+                                    height={40}
+                                />
+                            )
                         )}
                         <Button
                             size={'icon-xs'}

--- a/packages/common/components/chat-input/image-upload.tsx
+++ b/packages/common/components/chat-input/image-upload.tsx
@@ -1,8 +1,8 @@
 import { useChatStore } from '@repo/common/store';
-import { ChatModeConfig } from '@repo/shared/config';
+import { ChatModeConfig, ChatMode } from '@repo/shared/config';
 import { Button, Tooltip } from '@repo/ui';
 import { IconPaperclip } from '../icons';
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 
 export type TImageUpload = {
     id: string;
@@ -28,9 +28,15 @@ export const ImageUpload: FC<TImageUpload> = ({
         return null;
     }
 
+    const acceptAttr = useMemo(() => {
+        const base = 'image/jpeg,image/png,image/gif';
+        const allowPdf = chatMode === ChatMode.GEMINI_2_5_FLASH || chatMode === ChatMode.SMART_PDF_TO_EXCEL;
+        return allowPdf ? `${base},application/pdf,.pdf` : base;
+    }, [chatMode]);
+
     return (
         <>
-            <input type="file" id={id} className="hidden" onChange={handleImageUpload} multiple accept="image/jpeg,image/png,image/gif" />
+            <input type="file" id={id} className="hidden" onChange={handleImageUpload} multiple accept={acceptAttr} />
             <Tooltip content={tooltip}>
                 {showIcon ? (
                     <Button variant="ghost" size="icon-sm" onClick={handleFileSelect}>

--- a/packages/shared/utils/messages.ts
+++ b/packages/shared/utils/messages.ts
@@ -9,6 +9,8 @@ export const buildCoreMessagesFromThreadItems = ({
     query: string;
     imageAttachments?: string[];
 }) => {
+    const safeAttachments = (imageAttachments || []).filter(img => typeof img === 'string' && img.startsWith('data:image/'));
+
     const coreMessages = [
         ...(messages || []).flatMap(item => {
             const imgs = Array.isArray(item.imageAttachment)
@@ -38,10 +40,10 @@ export const buildCoreMessagesFromThreadItems = ({
         }),
         (() => {
             const finalContent: string | Array<{ type: 'text'; text: string } | { type: 'image'; image: string }> =
-                imageAttachments && imageAttachments.length > 0
+                safeAttachments && safeAttachments.length > 0
                     ? ([
                           { type: 'text', text: query || '' },
-                          ...imageAttachments.map(img => ({ type: 'image', image: img })),
+                          ...safeAttachments.map(img => ({ type: 'image', image: img })),
                       ] as Array<{ type: 'text'; text: string } | { type: 'image'; image: string }>)
                     : query || '';
             return {


### PR DESCRIPTION
# Enable PDF attachments for Gemini Flash and Smart PDF → Excel

This PR activates PDF selection and processing in the two targeted modes without changing the existing completion workflow or message structures.

## What’s included

- Allow selecting .pdf files (≤ 20 MB) ONLY for:
  - ChatMode.GEMINI_2_5_FLASH
  - ChatMode.SMART_PDF_TO_EXCEL
- Minimal UI change: show a small “PDF” badge (40×40) in the attachment area; image thumbnails remain unchanged.
- Server-side PDF text extraction endpoint:
  - New route: `POST /api/pdf/extract` (Node runtime)
  - Accepts one or more PDF files via FormData (`file` fields)
  - Uses `pdf-parse` to extract text; combines and truncates safely (~200k chars)
  - 20 MB per PDF limit, clear error messages
- Automatic prompt injection:
  - On send, client separates images vs PDFs
  - PDFs are sent to `/api/pdf/extract`, then the extracted text is appended to the user prompt under a header `[Pièce jointe PDF]`
  - Only image base64 data URLs are sent in the payload; PDFs are never sent as images
- Safety guard: message builder ignores any non-image data URLs (e.g., `data:application/pdf`) if they slip through

## Files changed

- `packages/common/components/chat-input/image-upload.tsx`
  - Dynamic `accept` attribute based on `chatMode`; includes `application/pdf,.pdf` only for the two modes above.
- `packages/common/hooks/use-image-attachment.ts`
  - Dynamically extends supported types; adds PDF when allowed
  - Enforces `MAX_FILE_SIZE_PDF = 20MB` (images remain 3MB)
  - Dropzone `accept` updated; improved toasts per type/size
- `packages/common/components/chat-input/image-attachment.tsx`
  - Adds conditional rendering for PDFs as a 40×40 badge with “PDF” and a tooltip (`title`) showing the file name
- `packages/common/components/chat-input/input.tsx`
  - Separates images vs PDFs on send
  - Calls `/api/pdf/extract` and injects combined text into the prompt
  - Sends only image base64s; counts only images in `imageAttachmentCount`
  - Adds client-side `pdfjs-dist` fallback if server extraction fails (keeps flow resilient)
- `apps/web/app/api/pdf/extract/route.ts` (new)
  - Node runtime route using `pdf-parse` to extract text server-side with a 15s timeout safeguard
- `packages/shared/utils/messages.ts`
  - Guard: only pass `data:image/*` attachments into core messages (ignore `data:application/pdf`)

## Why

- Enable PDFs for Gemini 2.5 Flash and the Smart PDF → Excel mode while keeping the rest of the app unchanged
- Avoid breaking the existing `/api/completion` and message pipeline
- Minimal UI footprint: a small, clear badge and no other interface changes

## Impact

- iPad Safari + desktop: PDFs are selectable in the two modes and display as a small badge
- On send, PDF text is injected automatically into the prompt; only image data is passed through the existing pipeline
- Other modes remain unchanged (PDFs are not selectable)

## How to test

1. Switch to `Gemini 2.5 Flash` or `Smart PDF → Excel`.
2. Attach a PDF ≤ 20 MB; ensure the file input allows selection, and a badge “PDF” appears in the attachment list.
3. Send a message:
   - Expect the prompt to include `\n\n[Pièce jointe PDF]\n` followed by extracted text.
   - Only images should be added as `imageAttachment_*` fields; PDFs are not included as images.
4. Try a PDF > 20 MB to see the error toast.
5. Switch to another mode (e.g., GPT 4.1) and confirm PDFs are not selectable.

## Notes

- `/api/completion` and workflow are unchanged.
- The server endpoint currently uses `pdf-parse`. If desired, we can switch the extraction to **Gemini 2.5 Flash** (Google) on the backend to perform OCR + table understanding, keeping the same front-end contract and limits.

## Summary (why)
- Enable critical PDF workflows in two modes without touching the core completion API
- Keep UI minimal and consistent with existing patterns
- Add a safe server endpoint, with a resilient client fallback


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/572a92e5-84af-11f0-a94e-3eef481a796b/task/2e7ab7d2-11da-4a0d-8213-2b4ee1a38ded))