### PR TITLE
Smart PDF to Excel: OCR via Gemini, Global table only + exports + UI/UX tweaks

### DIFF
--- a/apps/web/app/api/completion/stream-handlers.ts
+++ b/apps/web/app/api/completion/stream-handlers.ts
@@ -74,7 +74,7 @@ export async function executeStream({
             threadItemId: data.threadItemId,
             messages: data.messages,
             customInstructions: data.customInstructions,
-            webSearch: data.webSearch || false,
+            webSearch: (data.mode === 'smart-pdf-to-excel' ? false : (data.webSearch || false)),
             config: {
                 maxIterations: data.maxIterations || 3,
                 signal,
@@ -93,7 +93,7 @@ export async function executeStream({
                 parentThreadItemId: data.parentThreadItemId,
                 query: data.prompt,
                 mode: data.mode,
-                webSearch: data.webSearch || false,
+                webSearch: (data.mode === 'smart-pdf-to-excel' ? false : (data.webSearch || false)),
                 showSuggestions: data.showSuggestions || false,
                 [event]: payload,
             });
@@ -119,7 +119,7 @@ export async function executeStream({
                     userId,
                     query: data.prompt,
                     mode: data.mode,
-                    webSearch: data.webSearch || false,
+                    webSearch: (data.mode === 'smart-pdf-to-excel' ? false : (data.webSearch || false)),
                     showSuggestions: data.showSuggestions || false,
                     threadId: data.threadId,
                     threadItemId: data.threadItemId,

--- a/packages/ai/workflow/tasks/smart-pdf-to-excel-prompt.ts
+++ b/packages/ai/workflow/tasks/smart-pdf-to-excel-prompt.ts
@@ -3,42 +3,62 @@ export const SMART_PDF_TO_EXCEL_PROMPT = `
 
 Tu es un **Agent IA expert en OCR, extraction et structuration de données issues de factures PDF**.
 Tu es également un **expert en analyse de documents** et un **expert en extraction de texte brut**.
-Ta mission principale est de **convertir tout document PDF de facture fourni, qu'il s'agisse d'une ou de plusieurs pages, en un tableau Excel clair, structuré et cohérent**, sans jamais inventer de données.
+Ta mission principale est de **convertir tout document PDF de facture fourni, qu'il s'agisse d'une ou de plusieurs pages, en des tableaux Markdown clairs, structurés et cohérents**, sans jamais inventer de données.
 
 ---
 
 ## 🔹 Règles Fondamentales
-1. **Analyse et Fusion des Données :** Si plusieurs images ou pages sont fournies, traite-les comme un **document unique**, en intégrant toutes les informations dans un tableau cohérent, comme si elles provenaient d'une seule facture.
-2. Toujours analyser **le contenu exact des fichiers fournis**.
-3. Le tableau généré doit :
+1. Toujours analyser **le contenu exact des fichiers fournis**.
+2. Les tableaux générés doivent :
    - Reprendre uniquement les **colonnes présentes dans les PDF** (chaque facture peut avoir une structure différente).
-   - Être **structuré proprement** dans un format tabulaire clair (tableau Markdown, Excel ou CSV).
+   - Être **structurés proprement** au format **tableau Markdown uniquement** (pas de code fences \`\`\`).
    - Conserver les **valeurs exactes** (nombres, textes, montants) sans les modifier.
    - Respecter l’ordre et la hiérarchie des colonnes telles qu’elles apparaissent dans les documents.
-4. Tu ne dois **jamais inventer, compléter ou deviner** des informations absentes des fichiers.
-5. Si une information n’existe pas dans les fichiers, la laisser vide, mais conserver la colonne.
-6. Assure-toi que **les orthographes, montants et autres détails** soient **exacts à 100%**.
-7. Si des incohérences sont détectées entre les différents fichiers (par exemple : une colonne manquante dans certains fichiers), il faut le **signaler clairement**.
-
-## 🔹 Exemple d’Utilisation
-**Entrée :**
-(Importer un ou plusieurs PDF de facture contenant : Date, Numéro, Article, Qté, PU, TVA, Total)
-
-**Sortie attendue :**
-
-| Date       | N° Facture | Code Article | Désignation       | Qté | Prix Unitaire | TVA  | Total TTC |
-|------------|------------|--------------|------------------|-----|---------------|------|-----------|
-| 12/08/2025 | F-001245   | ART-001      | Chaise pliante    | 10  | 15.00 €       | 20%  | 180.00 €  |
-| 12/08/2025 | F-001245   | ART-002      | Table en bois     | 2   | 100.00 €      | 20%  | 240.00 €  |
+3. Tu ne dois **jamais inventer, compléter ou deviner** des informations absentes des fichiers.
+4. Si une information n’existe pas dans les fichiers, la laisser vide, mais conserver la colonne.
+5. Assure-toi que **les orthographes, montants et autres détails** soient **exacts à 100%**.
+6. Si des incohérences sont détectées entre les différents fichiers (ex.: une colonne manquante dans certains fichiers), il faut le **signaler clairement**.
 
 ---
 
-## 🔹 Instructions Clés
-- **Fusionner tous les fichiers** pour garantir que les informations sont analysées dans leur contexte global.
-- Toujours appliquer la **structure du PDF d’origine** à chaque facture, mais dans un format unifié.
-- Ne jamais ajouter de colonnes ou d’informations qui n’existent pas dans le PDF.
-- Si plusieurs factures ou plusieurs pages sont fournies, générer un **tableau multi-lignes complet** en conservant l’ordre et les hiérarchies.
-- Exiger une **vérification de l’orthographe** sur tous les champs texte pour éviter toute erreur de reconnaissance.
-- Agir toujours avec **rigueur et précision** dans l’analyse des factures.
+## 🔹 Sorties Exigées (toujours produire les deux)
+1) **Tableau Global Consolidé** (premier tableau Markdown de la réponse)
+   - Fusionne toutes les pages/documents fournis en un seul tableau.
+   - Utilise un **jeu d'en‑têtes cohérent** sur toutes les lignes.
+   - Si des colonnes existent dans certains documents mais pas d’autres, **conserve l’en‑tête** et laisse la cellule vide quand absente.
+
+2) **Tableaux Par Document/Page** (un tableau Markdown par document/page)
+   - Ajoute un **sous‑titre clair** avant chaque tableau (ex.: "Document 1", "Document 2", ou "Page 1", "Page 2").
+   - Les en‑têtes doivent rester **cohérents** entre ces tableaux autant que possible.
+   - En bas de chaque tableau, ajoute une courte ligne "Notes:" listant les **colonnes manquantes** ou particularités (si applicable).
+
+> Important: Sors uniquement des **titres/sous‑titres** et des **tableaux Markdown**. Pas d’autres paragraphes superflus.
+
+---
+
+## 🔹 Normalisation des en‑têtes
+- Choisis un **jeu d’en‑têtes global** à partir des colonnes rencontrées (ex.: Date, N° Facture, Code Article, Désignation, Qté, Prix Unitaire, TVA, Total TTC).
+- **Même ordre d’en‑têtes** entre le tableau global et les tableaux par document.
+- Ne renomme pas arbitrairement: respecte les intitulés présents; si des variantes légères existent (ex.: "PU" vs "Prix Unitaire"), harmonise intelligemment.
+
+---
+
+## 🔹 Exemple de Structure (illustratif)
+### Global
+| Date | N° Facture | Code Article | Désignation | Qté | Prix Unitaire | TVA | Total TTC |
+|------|------------|--------------|-------------|-----|---------------|-----|-----------|
+| ...  | ...        | ...          | ...         | ... | ...           | ... | ...       |
+
+### Document 1
+| Date | N° Facture | Code Article | Désignation | Qté | Prix Unitaire | TVA | Total TTC |
+|------|------------|--------------|-------------|-----|---------------|-----|-----------|
+| ...  | ...        | ...          | ...         | ... | ...           | ... | ...       |
+Notes: (ex.: colonne "TVA" absente dans ce document)
+
+### Document 2
+| Date | N° Facture | Code Article | Désignation | Qté | Prix Unitaire | TVA | Total TTC |
+|------|------------|--------------|-------------|-----|---------------|-----|-----------|
+| ...  | ...        | ...          | ...         | ... | ...           | ... | ...       |
+Notes: (ex.: RAS)
 `;
 

--- a/packages/ai/workflow/tasks/smart-pdf-to-excel-prompt.ts
+++ b/packages/ai/workflow/tasks/smart-pdf-to-excel-prompt.ts
@@ -2,63 +2,21 @@ export const SMART_PDF_TO_EXCEL_PROMPT = `
 # 📌 Prompt Système – Agent IA (Conversion PDF → Excel)
 
 Tu es un **Agent IA expert en OCR, extraction et structuration de données issues de factures PDF**.
-Tu es également un **expert en analyse de documents** et un **expert en extraction de texte brut**.
-Ta mission principale est de **convertir tout document PDF de facture fourni, qu'il s'agisse d'une ou de plusieurs pages, en des tableaux Markdown clairs, structurés et cohérents**, sans jamais inventer de données.
+Ta mission: **convertir toutes les pages/documents fournis en UN SEUL tableau Global (Markdown)**, clair et cohérent, sans jamais inventer.
 
----
+## Règles
+- Analyser uniquement le contenu des fichiers fournis.
+- Produire **un unique tableau Markdown** (sans blocs de code \`\`\`).
+- Fusionner toutes les pages/documents dans ce tableau Global.
+- **En‑têtes cohérents:** prends l’union des colonnes rencontrées; si une colonne manque dans un doc, laisse la cellule vide.
+- Respecter l’ordre des colonnes et conserver les valeurs exactes (texte, nombres, montants).
+- Aucune invention d’informations.
+- Sortie strictement limitée à un titre "### Global" suivi du tableau Markdown.
 
-## 🔹 Règles Fondamentales
-1. Toujours analyser **le contenu exact des fichiers fournis**.
-2. Les tableaux générés doivent :
-   - Reprendre uniquement les **colonnes présentes dans les PDF** (chaque facture peut avoir une structure différente).
-   - Être **structurés proprement** au format **tableau Markdown uniquement** (pas de code fences \`\`\`).
-   - Conserver les **valeurs exactes** (nombres, textes, montants) sans les modifier.
-   - Respecter l’ordre et la hiérarchie des colonnes telles qu’elles apparaissent dans les documents.
-3. Tu ne dois **jamais inventer, compléter ou deviner** des informations absentes des fichiers.
-4. Si une information n’existe pas dans les fichiers, la laisser vide, mais conserver la colonne.
-5. Assure-toi que **les orthographes, montants et autres détails** soient **exacts à 100%**.
-6. Si des incohérences sont détectées entre les différents fichiers (ex.: une colonne manquante dans certains fichiers), il faut le **signaler clairement**.
-
----
-
-## 🔹 Sorties Exigées (toujours produire les deux)
-1) **Tableau Global Consolidé** (premier tableau Markdown de la réponse)
-   - Fusionne toutes les pages/documents fournis en un seul tableau.
-   - Utilise un **jeu d'en‑têtes cohérent** sur toutes les lignes.
-   - Si des colonnes existent dans certains documents mais pas d’autres, **conserve l’en‑tête** et laisse la cellule vide quand absente.
-
-2) **Tableaux Par Document/Page** (un tableau Markdown par document/page)
-   - Ajoute un **sous‑titre clair** avant chaque tableau (ex.: "Document 1", "Document 2", ou "Page 1", "Page 2").
-   - Les en‑têtes doivent rester **cohérents** entre ces tableaux autant que possible.
-   - En bas de chaque tableau, ajoute une courte ligne "Notes:" listant les **colonnes manquantes** ou particularités (si applicable).
-
-> Important: Sors uniquement des **titres/sous‑titres** et des **tableaux Markdown**. Pas d’autres paragraphes superflus.
-
----
-
-## 🔹 Normalisation des en‑têtes
-- Choisis un **jeu d’en‑têtes global** à partir des colonnes rencontrées (ex.: Date, N° Facture, Code Article, Désignation, Qté, Prix Unitaire, TVA, Total TTC).
-- **Même ordre d’en‑têtes** entre le tableau global et les tableaux par document.
-- Ne renomme pas arbitrairement: respecte les intitulés présents; si des variantes légères existent (ex.: "PU" vs "Prix Unitaire"), harmonise intelligemment.
-
----
-
-## 🔹 Exemple de Structure (illustratif)
+## Format attendu
 ### Global
-| Date | N° Facture | Code Article | Désignation | Qté | Prix Unitaire | TVA | Total TTC |
-|------|------------|--------------|-------------|-----|---------------|-----|-----------|
-| ...  | ...        | ...          | ...         | ... | ...           | ... | ...       |
-
-### Document 1
-| Date | N° Facture | Code Article | Désignation | Qté | Prix Unitaire | TVA | Total TTC |
-|------|------------|--------------|-------------|-----|---------------|-----|-----------|
-| ...  | ...        | ...          | ...         | ... | ...           | ... | ...       |
-Notes: (ex.: colonne "TVA" absente dans ce document)
-
-### Document 2
-| Date | N° Facture | Code Article | Désignation | Qté | Prix Unitaire | TVA | Total TTC |
-|------|------------|--------------|-------------|-----|---------------|-----|-----------|
-| ...  | ...        | ...          | ...         | ... | ...           | ... | ...       |
-Notes: (ex.: RAS)
+| Colonne 1 | Colonne 2 | ... |
+|-----------|-----------|-----|
+| ...       | ...       | ... |
 `;
 

--- a/packages/common/components/chat-input/animated-input.tsx
+++ b/packages/common/components/chat-input/animated-input.tsx
@@ -57,6 +57,8 @@ export const AnimatedChatInput = ({
 
     const stopGeneration = useChatStore(state => state.stopGeneration);
     const { dropzonProps, readImageFile } = useImageAttachment();
+    const [showExtractionPrompt, setShowExtractionPrompt] = React.useState(false);
+    const extractionLabel = 'Toutes les tables';
     const { push } = useRouter();
     const chatMode = useChatStore(state => state.chatMode);
     const setChatMode = useChatStore(state => state.setChatMode);
@@ -295,7 +297,9 @@ export const AnimatedChatInput = ({
 
         // Submit the message
         const formData = new FormData();
-        formData.append('query', value);
+        const shouldEmbedExtraction = chatMode === ChatMode.SMART_PDF_TO_EXCEL && (imageAttachments?.length || 0) > 0;
+        const effectiveQuery = shouldEmbedExtraction ? `Mode d’extraction: ${extractionLabel}\n${value}` : value;
+        formData.append('query', effectiveQuery);
         if (imageAttachments && imageAttachments.length > 0) {
             imageAttachments.forEach((img, index) => {
                 if (img.base64) {
@@ -321,10 +325,14 @@ export const AnimatedChatInput = ({
         setInputValue('');
         clearImageAttachments();
         setShowSuggestions(false);
+        setShowExtractionPrompt(false);
     };
 
     const handleFileAttachment = (file: File) => {
         readImageFile(file);
+        if (chatMode === ChatMode.SMART_PDF_TO_EXCEL) {
+            setShowExtractionPrompt(true);
+        }
     };
 
     const handleModelChange = (modelId: string) => {
@@ -349,6 +357,19 @@ export const AnimatedChatInput = ({
                         {(imageAttachments?.length || 0) > 0 && (
                             <div className="mb-2">
                                 <ImageAttachment />
+                            </div>
+                        )}
+                        {chatMode === ChatMode.SMART_PDF_TO_EXCEL && (imageAttachments?.length || 0) > 0 && showExtractionPrompt && (
+                            <div className="mb-2 rounded-md border p-2 text-xs flex items-center justify-between" style={{ backgroundColor: 'hsl(var(--chat-input-surface-bg))', borderColor: 'hsl(var(--chat-input-border))' }}>
+                                <span>Quel mode d’extraction souhaitez-vous appliquer ?</span>
+                                <button
+                                    type="button"
+                                    onClick={() => setShowExtractionPrompt(false)}
+                                    className="px-2 py-1 rounded border text-[11px]"
+                                    style={{ backgroundColor: 'hsl(var(--chat-input-control-bg))', borderColor: 'hsl(var(--chat-input-border))' }}
+                                >
+                                    Appliquer « {extractionLabel} »
+                                </button>
                             </div>
                         )}
                         <AI_Prompt

--- a/packages/common/components/chat-input/animated-input.tsx
+++ b/packages/common/components/chat-input/animated-input.tsx
@@ -360,7 +360,7 @@ export const AnimatedChatInput = ({
                             selectedModel={chatMode}
                             onModelChange={handleModelChange}
                             onAttachFile={ChatModeConfig[chatMode]?.imageUpload ? handleFileAttachment : undefined}
-                            fileAccept={chatMode === ChatMode.GEMINI_2_5_FLASH ? 'image/jpeg,image/png,image/gif,application/pdf' : 'image/jpeg,image/png,image/gif'}
+                            fileAccept={(chatMode === ChatMode.GEMINI_2_5_FLASH || chatMode === ChatMode.SMART_PDF_TO_EXCEL) ? 'image/jpeg,image/png,image/gif,application/pdf' : 'image/jpeg,image/png,image/gif'}
                             disabled={isGenerating}
                             showWebToggle={!!(ChatModeConfig[chatMode]?.webSearch || hasApiKeyForChatMode(chatMode))}
                             webSearchEnabled={useWebSearch}

--- a/packages/common/components/chat-input/animated-input.tsx
+++ b/packages/common/components/chat-input/animated-input.tsx
@@ -360,6 +360,7 @@ export const AnimatedChatInput = ({
                             selectedModel={chatMode}
                             onModelChange={handleModelChange}
                             onAttachFile={ChatModeConfig[chatMode]?.imageUpload ? handleFileAttachment : undefined}
+                            fileAccept={chatMode === ChatMode.GEMINI_2_5_FLASH ? 'image/jpeg,image/png,image/gif,application/pdf' : 'image/jpeg,image/png,image/gif'}
                             disabled={isGenerating}
                             showWebToggle={!!(ChatModeConfig[chatMode]?.webSearch || hasApiKeyForChatMode(chatMode))}
                             webSearchEnabled={useWebSearch}

--- a/packages/common/components/mdx/mdx-components.tsx
+++ b/packages/common/components/mdx/mdx-components.tsx
@@ -1,7 +1,9 @@
 import { CitationProviderContext, CodeBlock, LinkPreviewPopover } from '@repo/common/components';
 import { isValidUrl } from '@repo/shared/utils';
 import { MDXRemote } from 'next-mdx-remote/rsc';
-import { ComponentProps, ReactElement, useContext, useRef } from 'react';
+import { Button } from '@repo/ui';
+import { IconCheck, IconFileSpreadsheet, IconFileTypeCsv } from '@tabler/icons-react';
+import { ComponentProps, ReactElement, useContext, useRef, useState } from 'react';
 import * as XLSX from 'xlsx';
 
 function tableToAOA(table: HTMLTableElement): string[][] {
@@ -36,12 +38,15 @@ function downloadXLSX(aoa: string[][], filename = 'extraction.xlsx') {
 
 const TableWithExport = ({ children, ...props }: any) => {
     const tableRef = useRef<HTMLTableElement | null>(null);
+    const [justDownloaded, setJustDownloaded] = useState<null | 'csv' | 'xlsx'>(null);
     const handleDownload = (type: 'csv' | 'xlsx') => {
         if (!tableRef.current) return;
         const aoa = tableToAOA(tableRef.current);
         if (!aoa || aoa.length === 0) return;
         if (type === 'csv') downloadCSV(aoa);
         else downloadXLSX(aoa);
+        setJustDownloaded(type);
+        setTimeout(() => setJustDownloaded(null), 1500);
     };
     return (
         <div className="relative">
@@ -49,8 +54,12 @@ const TableWithExport = ({ children, ...props }: any) => {
                 {children}
             </table>
             <div className="absolute right-1 top-1 flex gap-1">
-                <button type="button" onClick={() => handleDownload('csv')} className="text-[10px] px-1.5 py-0.5 rounded bg-[hsl(var(--chat-input-control-bg))] hover:bg-[hsl(var(--chat-input-control-hover-bg))] border border-[hsl(var(--chat-input-border))]">CSV</button>
-                <button type="button" onClick={() => handleDownload('xlsx')} className="text-[10px] px-1.5 py-0.5 rounded bg-[hsl(var(--chat-input-control-bg))] hover:bg-[hsl(var(--chat-input-control-hover-bg))] border border-[hsl(var(--chat-input-border))]">XLSX</button>
+                <Button size="icon-sm" variant="ghost" tooltip="Télécharger CSV" onClick={() => handleDownload('csv')}>
+                    {justDownloaded === 'csv' ? <IconCheck size={14} /> : <IconFileTypeCsv size={14} />}
+                </Button>
+                <Button size="icon-sm" variant="ghost" tooltip="Télécharger XLSX" onClick={() => handleDownload('xlsx')}>
+                    {justDownloaded === 'xlsx' ? <IconCheck size={14} /> : <IconFileSpreadsheet size={14} />}
+                </Button>
             </div>
         </div>
     );

--- a/packages/common/components/thread/components/markdown-content.tsx
+++ b/packages/common/components/thread/components/markdown-content.tsx
@@ -8,8 +8,9 @@ import { cn } from '@repo/ui';
 import { MDXRemote } from 'next-mdx-remote';
 import { MDXRemoteSerializeResult } from 'next-mdx-remote/rsc';
 import { serialize } from 'next-mdx-remote/serialize';
-import { memo, Suspense, useEffect, useState } from 'react';
+import { memo, Suspense, useEffect, useRef, useState } from 'react';
 import remarkGfm from 'remark-gfm';
+import * as XLSX from 'xlsx';
 
 export const markdownStyles = {
     'animate-fade-in prose prose-sm min-w-full': true,

--- a/packages/common/components/thread/components/markdown-content.tsx
+++ b/packages/common/components/thread/components/markdown-content.tsx
@@ -53,6 +53,7 @@ type MarkdownContentProps = {
     shouldAnimate?: boolean;
     isCompleted?: boolean;
     isLast?: boolean;
+    totalAttachments?: number;
 };
 
 type NestedChunk = {
@@ -105,13 +106,23 @@ function parseCitationsWithSourceTags(markdown: string): string {
 }
 
 export const MarkdownContent = memo(
-    ({ content, className, isCompleted, isLast }: MarkdownContentProps) => {
+    ({ content, className, isCompleted, isLast, totalAttachments }: MarkdownContentProps) => {
         const [previousContent, setPreviousContent] = useState<string[]>([]);
         const [currentContent, setCurrentContent] = useState<string>('');
         const { chunkMdx } = useMdxChunker();
+        const containerRef = useRef<HTMLDivElement | null>(null);
+        const [tableCount, setTableCount] = useState<number>(0);
 
         useEffect(() => {
             if (!content) return;
+
+            // Count tables after content updates
+            setTimeout(() => {
+                if (containerRef.current) {
+                    const count = containerRef.current.querySelectorAll('table').length;
+                    setTableCount(count);
+                }
+            }, 0);
 
             (async () => {
                 try {
@@ -139,9 +150,89 @@ export const MarkdownContent = memo(
             })();
         }, [content, isCompleted]);
 
+        const renderExportBar = () => {
+            const shouldShowMulti = (tableCount > 1) || ((totalAttachments || 0) > 1);
+            if (!shouldShowMulti) return null;
+
+            const tableToAOA = (table: HTMLTableElement): string[][] => {
+                const rows = Array.from(table.querySelectorAll('tr')) as HTMLTableRowElement[];
+                const aoa: string[][] = [];
+                for (const row of rows) {
+                    const cells = Array.from(row.querySelectorAll('th,td')) as (HTMLTableCellElement)[];
+                    const rowData = cells.map(cell => (cell.textContent || '').trim());
+                    if (rowData.length > 0) aoa.push(rowData);
+                }
+                return aoa;
+            };
+
+            const exportMultiXLSX = () => {
+                if (!containerRef.current) return;
+                const tables = Array.from(containerRef.current.querySelectorAll('table')) as HTMLTableElement[];
+                if (tables.length === 0) return;
+                const wb = XLSX.utils.book_new();
+                tables.forEach((t, i) => {
+                    const aoa = tableToAOA(t);
+                    const ws = XLSX.utils.aoa_to_sheet(aoa);
+                    XLSX.utils.book_append_sheet(wb, ws, `Doc ${i + 1}`);
+                });
+                XLSX.writeFile(wb, 'extraction-multi.xlsx');
+            };
+
+            const exportGlobalXLSX = () => {
+                if (!containerRef.current) return;
+                const tables = Array.from(containerRef.current.querySelectorAll('table')) as HTMLTableElement[];
+                if (tables.length === 0) return;
+                const all: string[][] = [];
+                tables.forEach((t, idx) => {
+                    const aoa = tableToAOA(t);
+                    if (idx === 0) {
+                        all.push(...aoa);
+                    } else {
+                        // skip header row if shapes match and header likely present
+                        const dataRows = aoa.length > 1 ? aoa.slice(1) : aoa;
+                        all.push(...dataRows);
+                    }
+                });
+                const ws = XLSX.utils.aoa_to_sheet(all);
+                const wb = XLSX.utils.book_new();
+                XLSX.utils.book_append_sheet(wb, ws, 'Global');
+                XLSX.writeFile(wb, 'extraction-global.xlsx');
+            };
+
+            const exportGlobalCSV = () => {
+                if (!containerRef.current) return;
+                const tables = Array.from(containerRef.current.querySelectorAll('table')) as HTMLTableElement[];
+                if (tables.length === 0) return;
+                const all: string[][] = [];
+                tables.forEach((t, idx) => {
+                    const aoa = tableToAOA(t);
+                    if (idx === 0) all.push(...aoa);
+                    else all.push(...(aoa.length > 1 ? aoa.slice(1) : aoa));
+                });
+                const escape = (s: string) => '"' + s.replace(/"/g, '""') + '"';
+                const csv = all.map(r => r.map(escape).join(',')).join('\n');
+                const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = 'extraction-global.csv';
+                a.click();
+                URL.revokeObjectURL(url);
+            };
+
+            return (
+                <div className="not-prose mb-2 flex items-center justify-end gap-2">
+                    <button type="button" onClick={exportGlobalCSV} className="text-[10px] px-1.5 py-0.5 rounded bg-[hsl(var(--chat-input-control-bg))] hover:bg-[hsl(var(--chat-input-control-hover-bg))] border border-[hsl(var(--chat-input-border))]">CSV global</button>
+                    <button type="button" onClick={exportGlobalXLSX} className="text-[10px] px-1.5 py-0.5 rounded bg-[hsl(var(--chat-input-control-bg))] hover:bg-[hsl(var(--chat-input-control-hover-bg))] border border-[hsl(var(--chat-input-border))]">XLSX global</button>
+                    <button type="button" onClick={exportMultiXLSX} className="text-[10px] px-1.5 py-0.5 rounded bg-[hsl(var(--chat-input-control-bg))] hover:bg-[hsl(var(--chat-input-control-hover-bg))] border border-[hsl(var(--chat-input-border))]">XLSX multi‑onglets</button>
+                </div>
+            );
+        };
+
         if (isCompleted && !isLast) {
             return (
-                <div className={cn('', markdownStyles, className)}>
+                <div className={cn('', markdownStyles, className)} ref={containerRef}>
+                    {renderExportBar()}
                     <ErrorBoundary fallback={<ErrorPlaceholder />}>
                         <MemoizedMdxChunk chunk={currentContent} />
                     </ErrorBoundary>
@@ -150,7 +241,8 @@ export const MarkdownContent = memo(
         }
 
         return (
-            <div className={cn('', markdownStyles, className)}>
+            <div className={cn('', markdownStyles, className)} ref={containerRef}>
+                {renderExportBar()}
                 {previousContent.length > 0 &&
                     previousContent.map((chunk, index) => (
                         <ErrorBoundary fallback={<ErrorPlaceholder />} key={`prev-${index}`}>

--- a/packages/common/components/thread/thread-item.tsx
+++ b/packages/common/components/thread/thread-item.tsx
@@ -120,6 +120,7 @@ export const ThreadItem = memo(
                                             )
                                         }
                                         isLast={isLast}
+                                        totalAttachments={Array.isArray(threadItem?.imageAttachment) ? threadItem.imageAttachment.length : (threadItem?.imageAttachment ? 1 : 0)}
                                     />
                                 </div>
                             )}

--- a/packages/common/hooks/use-image-attachment.ts
+++ b/packages/common/hooks/use-image-attachment.ts
@@ -29,7 +29,7 @@ export const useImageAttachment = () => {
             'image/png': ['.png'],
             'image/gif': ['.gif'],
         };
-        if (chatMode === ChatMode.GEMINI_2_5_FLASH) {
+        if (chatMode === ChatMode.GEMINI_2_5_FLASH || chatMode === ChatMode.SMART_PDF_TO_EXCEL) {
             base['application/pdf'] = ['.pdf'];
         }
         return base;
@@ -37,7 +37,7 @@ export const useImageAttachment = () => {
 
     const readFilesToAttachments = async (files: File[]): Promise<{ base64?: string; file?: File }[]> => {
         const results: { base64?: string; file?: File }[] = [];
-        const pdfAllowed = chatMode === ChatMode.GEMINI_2_5_FLASH;
+        const pdfAllowed = chatMode === ChatMode.GEMINI_2_5_FLASH || chatMode === ChatMode.SMART_PDF_TO_EXCEL;
 
         for (const file of files) {
             const isPDF = file.type === 'application/pdf';
@@ -91,7 +91,7 @@ export const useImageAttachment = () => {
 
     const addFiles = async (files: File[]) => {
         if (!files?.length) return;
-        const pdfAllowed = chatMode === ChatMode.GEMINI_2_5_FLASH;
+        const pdfAllowed = chatMode === ChatMode.GEMINI_2_5_FLASH || chatMode === ChatMode.SMART_PDF_TO_EXCEL;
         let availableSlots = Math.max(0, MAX_ATTACHMENTS - (imageAttachments?.length || 0));
         if (availableSlots <= 0) {
             toast({

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -19,7 +19,8 @@
     "@repo/ui": "*",
     "@repo/actions": "*",
     "@tiptap/extension-character-count": "^2.11.7",
-    "react-intl": "^6.6.3"
+    "react-intl": "^6.6.3",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@repo/typescript-config": "*",

--- a/packages/shared/config/chat-mode.ts
+++ b/packages/shared/config/chat-mode.ts
@@ -149,7 +149,7 @@ export const ChatModeConfig: Record<
         isAuthRequired: false,
     },
     [ChatMode.SMART_PDF_TO_EXCEL]: {
-        webSearch: true,
+        webSearch: false,
         imageUpload: true,
         retry: true,
         isNew: true,

--- a/packages/ui/src/components/animated-ai-input.tsx
+++ b/packages/ui/src/components/animated-ai-input.tsx
@@ -193,6 +193,7 @@ interface AI_PromptProps {
     selectedModel?: string;
     onModelChange?: (model: string) => void;
     onAttachFile?: (file: File) => void;
+    fileAccept?: string;
     disabled?: boolean;
     showWebToggle?: boolean;
     webSearchEnabled?: boolean;
@@ -209,6 +210,7 @@ export function AI_Prompt({
     selectedModel: controlledSelectedModel,
     onModelChange,
     onAttachFile,
+    fileAccept,
     disabled = false,
     showWebToggle = false,
     webSearchEnabled = false,
@@ -435,7 +437,7 @@ export function AI_Prompt({
                                                 className="hidden" 
                                                 onChange={handleFileInputChange}
                                                 disabled={disabled}
-                                                accept="image/jpeg,image/png,image/gif"
+                                                accept={fileAccept ?? 'image/jpeg,image/png,image/gif'}
                                             />
                                             <Paperclip className="w-4 h-4" />
                                         </label>


### PR DESCRIPTION
# Smart PDF to Excel — OCR via Gemini (Global table only)

Changes
— UI: PDF/images accepted for Gemini Flash and Smart PDF to Excel; removal of Web search toggle for Smart PDF to Excel and forced false server-side.
— UI: Added per-table CSV/XLSX icons, global CSV/XLSX export bar, and multi-worksheet XLSX (disabled if single table).
— UI: Post-import banner asks extraction mode; default applies « Toutes les tables ».
— Prompt: simplified to produce only ONE Global Markdown table (fusion across all pages/docs), union headers, no per-document tables (token savings).
— Fix: TypeScript imports (useRef, XLSX) and export UX (icons, tooltips, confirmation).

Test checklist
- On /chat, Smart PDF to Excel accepts images+PDF (≤10MB PDF).
- Upload multiple PDFs or multi-page PDFs, send: ensure output contains a single Global Markdown table (no per-document tables).
- Headers are consistent; if some docs lack a column, cells are empty in those rows.
- CSV global/XLSX global export buttons work and download files; check data integrity.
- XLSX multi-onglets button appears disabled when only one table is present.
- Per-table CSV/XLSX icons appear on the Global table; clicking shows a brief check confirmation.
- Web search toggle not visible for Smart PDF to Excel; server ignores webSearch=true.

Notes
- Router unchanged; Smart PDF to Excel → smart-pdf-to-excel task.
