### PR TITLE
Fix: affichage conditionnel de la barre d'export globale

### DIFF
--- a/packages/common/components/thread/components/markdown-content.tsx
+++ b/packages/common/components/thread/components/markdown-content.tsx
@@ -4,6 +4,8 @@ import {
     mdxComponents,
     useMdxChunker,
 } from '@repo/common/components';
+import { useChatStore } from '@repo/common/store';
+import { ChatMode } from '@repo/shared/config';
 import { Button, cn } from '@repo/ui';
 import { MDXRemote } from 'next-mdx-remote';
 import { MDXRemoteSerializeResult } from 'next-mdx-remote/rsc';
@@ -115,6 +117,7 @@ export const MarkdownContent = memo(
         const containerRef = useRef<HTMLDivElement | null>(null);
         const [tableCount, setTableCount] = useState<number>(0);
         const [lastDownloaded, setLastDownloaded] = useState<null | 'csv' | 'xlsx' | 'xlsx-multi'>(null);
+        const chatMode = useChatStore(state => state.chatMode);
 
         useEffect(() => {
             if (!content) return;
@@ -154,6 +157,16 @@ export const MarkdownContent = memo(
         }, [content, isCompleted]);
 
         const renderExportBar = () => {
+            // Vérifier si on doit afficher la barre d'export
+            const shouldShowExportBar = 
+                [ChatMode.SMART_PDF_TO_EXCEL, ChatMode.GEMINI_2_5_FLASH].includes(chatMode) &&
+                tableCount > 0 &&
+                typeof totalAttachments !== 'undefined'; // Éviter l'affichage sur les pages non-chat (privacy/terms)
+            
+            if (!shouldShowExportBar) {
+                return null;
+            }
+
             const hasMultiple = (tableCount > 1) || ((totalAttachments || 0) > 1);
             const disableMulti = !hasMultiple;
 


### PR DESCRIPTION
## Objectif
Corriger l'affichage des icônes d'export (CSV, XLSX, XLSX multi-onglets) dans la barre globale afin qu'elles n'apparaissent que pour les modes appropriés et uniquement lorsqu'au moins un tableau est détecté.

## Changements effectués

### ✅ Conditions d'affichage de la barre d'export globale
- **Modes autorisés** : Smart PDF to Excel et Gemini 2.5 Flash uniquement
- **Détection de tableaux** : La barre ne s'affiche que si `tableCount > 0`
- **Protection contexte** : Vérifie `typeof totalAttachments !== 'undefined'` pour éviter l'affichage sur les pages non-chat (privacy/terms)

### 🔧 Détails techniques
- Import de `useChatStore` et `ChatMode` ajoutés dans le composant `MarkdownContent`
- Récupération du mode courant via `useChatStore(state => state.chatMode)`
- Logique conditionnelle implémentée dans `renderExportBar()` avec retour `null` si conditions non remplies
- La logique `disableMulti` reste inchangée (basée sur le nombre de tableaux et documents)

### ✨ Points non modifiés
- Les petits boutons d'export intégrés à chaque `<table>` restent visibles dans tous les modes
- Le streaming/MDX chunking n'est pas impacté
- Pas de modification dans `mdx-components.tsx`

## Critères d'acceptation validés
- ✅ Mode = Smart PDF to Excel, tableCount > 0 → barre globale visible
- ✅ Mode = Gemini 2.5 Flash, tableCount > 0 → barre globale visible  
- ✅ Mode = Gemini 2.5 Flash, tableCount = 0 → barre globale non visible
- ✅ Mode = Gemini 2.5 Pro (ou tout autre mode), même avec tableau → barre globale non visible
- ✅ Pages privacy/terms → barre globale non visible
- ✅ Boutons CSV/XLSX par tableau → restent visibles comme aujourd'hui