### PR TITLE
feat: Red Abanalka animated background behind AI_Prompt (home only)

### DIFF
--- a/packages/common/components/chat-input/animated-input.tsx
+++ b/packages/common/components/chat-input/animated-input.tsx
@@ -8,7 +8,7 @@ import {
 } from '@repo/common/components';
 import { useImageAttachment } from '@repo/common/hooks';
 import { CHAT_MODE_CREDIT_COSTS, ChatMode, ChatModeConfig, getChatModeName, getShineColors } from '@repo/shared/config';
-import { cn, Flex, AI_Prompt, ModelIcons, useToast, GridGradientBackground } from '@repo/ui';
+import { cn, Flex, AI_Prompt, ModelIcons, useToast, GridGradientBackground, RedBeamBackground } from '@repo/ui';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useParams, usePathname, useRouter } from 'next/navigation';
 import React, { useEffect } from 'react';
@@ -433,10 +433,16 @@ export const AnimatedChatInput = ({
                     : 'absolute inset-0 flex h-full w-full flex-col items-center justify-center'
             )}
         >
-            {!currentThreadId && <GridGradientBackground side="left" variant={backgroundVariant} />}
+            {!currentThreadId && (
+                backgroundVariant === 'red-beam' ? (
+                    <RedBeamBackground className="hidden md:block absolute inset-0 z-0 pointer-events-none" />
+                ) : (
+                    <GridGradientBackground side="left" variant={backgroundVariant as any} />
+                )
+            )}
             <div
                 className={cn(
-                    'mx-auto flex w-full max-w-3xl flex-col items-start',
+                    'relative z-10 mx-auto flex w-full max-w-3xl flex-col items-start',
                     !threadItemsLength && 'justify-start',
                     !currentThreadId && 'px-8'
                 )}

--- a/packages/common/components/chat-input/animated-input.tsx
+++ b/packages/common/components/chat-input/animated-input.tsx
@@ -437,7 +437,7 @@ export const AnimatedChatInput = ({
                 backgroundVariant === 'red-beam' ? (
                     <RedBeamBackground className="hidden md:block absolute inset-0 z-0 pointer-events-none" />
                 ) : (
-                    <GridGradientBackground side="left" variant={backgroundVariant as any} />
+                    <GridGradientBackground side="left" variant={backgroundVariant === 'old' ? 'old' : 'new'} />
                 )
             )}
             <div

--- a/packages/common/components/chat-input/input.tsx
+++ b/packages/common/components/chat-input/input.tsx
@@ -7,7 +7,7 @@ import {
 } from '@repo/common/components';
 import { useImageAttachment } from '@repo/common/hooks';
 import { ChatModeConfig, ChatMode } from '@repo/shared/config';
-import { cn, Flex, GridGradientBackground } from '@repo/ui';
+import { cn, Flex, GridGradientBackground, RedBeamBackground } from '@repo/ui';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useParams, usePathname, useRouter } from 'next/navigation';
 import React, { useEffect } from 'react';
@@ -254,7 +254,11 @@ export const ChatInput = ({
             )}
         >
             {!currentThreadId && (
-                <GridGradientBackground side="left" variant={backgroundVariant === 'old' ? 'old' : 'new'} />
+                backgroundVariant === 'red-beam' ? (
+                    <RedBeamBackground className="hidden md:block absolute inset-0 z-0 pointer-events-none" />
+                ) : (
+                    <GridGradientBackground side="left" variant={backgroundVariant === 'old' ? 'old' : 'new'} />
+                )
             )}
             <div
                 className={cn(

--- a/packages/common/components/chat-input/input.tsx
+++ b/packages/common/components/chat-input/input.tsx
@@ -253,7 +253,9 @@ export const ChatInput = ({
                     : 'absolute inset-0 flex h-full w-full flex-col items-center justify-center'
             )}
         >
-            {!currentThreadId && <GridGradientBackground side="left" variant={backgroundVariant} />}
+            {!currentThreadId && (
+                <GridGradientBackground side="left" variant={backgroundVariant === 'old' ? 'old' : 'new'} />
+            )}
             <div
                 className={cn(
                     'mx-auto flex w-full max-w-3xl flex-col items-start',

--- a/packages/common/components/settings-modal.tsx
+++ b/packages/common/components/settings-modal.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useMcpToolsStore, usePreferencesStore } from '@repo/common/store';
+import type { BackgroundVariant } from '@repo/common/store';
 import { Alert, AlertDescription, DialogFooter, ShineBorder, RadioGroup, RadioGroupItem } from '@repo/ui';
 import { Button } from '@repo/ui/src/components/button';
 import { IconBolt, IconBoltFilled, IconKey, IconSettings2, IconTrash } from './icons';
@@ -529,11 +530,12 @@ export const PersonalizationSettings = () => {
                     id="background-select"
                     className="w-40 rounded-md border bg-background px-2 py-1 text-sm"
                     value={backgroundVariant}
-                    onChange={(e) => setBackgroundVariant(e.target.value as 'new' | 'old')}
+                    onChange={(e) => setBackgroundVariant(e.target.value as BackgroundVariant)}
                     aria-label={t('settings.personalization.background.title')}
                 >
                     <option value="new">{t('settings.personalization.background.new')}</option>
                     <option value="old">{t('settings.personalization.background.old')}</option>
+                    <option value="red-beam">{t('settings.personalization.background.red_beam')}</option>
                 </select>
                 <p className="text-muted-foreground text-xs">Actif uniquement en mode sombre</p>
             </div>

--- a/packages/common/i18n/en.json
+++ b/packages/common/i18n/en.json
@@ -49,6 +49,7 @@
   "settings.personalization.background.title": "Background style",
   "settings.personalization.background.new": "New",
   "settings.personalization.background.old": "Old",
+  "settings.personalization.background.red_beam": "Red Abanalka",
   "settings.personalization.shine.title": "Shine border colors",
   "settings.personalization.shine.description": "Choose a 3‑color preset for the animated chat input border.",
   "settings.personalization.shine.palette1": "Palette 1",

--- a/packages/common/i18n/fr.json
+++ b/packages/common/i18n/fr.json
@@ -49,6 +49,7 @@
   "settings.personalization.background.title": "Style d’arrière‑plan",
   "settings.personalization.background.new": "Nouveau",
   "settings.personalization.background.old": "Ancien",
+  "settings.personalization.background.red_beam": "Red Abanalka",
   "settings.personalization.shine.title": "Couleurs de la bordure lumineuse",
   "settings.personalization.shine.description": "Choisissez un préréglage de 3 couleurs pour la bordure animée de l’entrée de chat.",
   "settings.personalization.shine.palette1": "Palette 1",

--- a/packages/common/store/preferences.store.ts
+++ b/packages/common/store/preferences.store.ts
@@ -5,7 +5,7 @@ import { createJSONStorage, persist } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 import type { ShinePreset } from '@repo/shared/config';
 
-export type BackgroundVariant = 'new' | 'old';
+export type BackgroundVariant = 'new' | 'old' | 'red-beam';
 
 type PreferencesState = {
   backgroundVariant: BackgroundVariant;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,7 +20,8 @@
     "input-otp": "^1.4.2",
     "lucide-react": "^0.468.0",
     "tailwind-merge": "^2.0.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "three": "^0.163.0"
   },
   "devDependencies": {
     "@repo/typescript-config": "*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -27,6 +27,7 @@
     "@repo/typescript-config": "*",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
+    "@types/three": "^0.163.0",
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.31",
     "react": "^18.2.0",

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -43,5 +43,6 @@ export * from './shine-border';
 
 // Export specific components that are needed
 export * from './grid-gradient-background';
+export * from './red-beam-background';
 
 export { AI_Prompt, ModelIcons } from './animated-ai-input';

--- a/packages/ui/src/components/red-beam-background.tsx
+++ b/packages/ui/src/components/red-beam-background.tsx
@@ -1,0 +1,301 @@
+"use client";
+import React, { useEffect, useMemo, useRef } from "react";
+import * as THREE from "three";
+
+export interface RedBeamBackgroundProps {
+  className?: string;
+  style?: React.CSSProperties;
+  color?: string;
+  intensity?: number;
+  mouseTiltStrength?: number;
+  performance?: { minFps?: number; maxFps?: number; dprFloor?: number };
+}
+
+function supportsWebGL(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const canvas = document.createElement("canvas");
+    return !!(
+      canvas.getContext("webgl2") ||
+      canvas.getContext("webgl") ||
+      canvas.getContext("experimental-webgl")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function createFullscreenTriangle() {
+  const geometry = new THREE.BufferGeometry();
+  const vertices = new Float32Array([
+    -1, -1, 0,
+    3, -1, 0,
+    -1, 3, 0,
+  ]);
+  geometry.setAttribute("position", new THREE.BufferAttribute(vertices, 3));
+  return geometry;
+}
+
+const vertexShader = `#version 300 es
+precision highp float;
+layout(location = 0) in vec3 position;
+
+out vec2 vUv;
+
+void main() {
+  vUv = position.xy * 0.5 + 0.5;
+  gl_Position = vec4(position, 1.0);
+}
+`;
+
+const fragmentShader = `#version 300 es
+precision highp float;
+
+in vec2 vUv;
+out vec4 outColor;
+
+uniform float uTime;
+uniform vec2 uResolution;
+uniform vec3 uColor;
+uniform float uIntensity;
+uniform float uAlpha;
+uniform vec2 uBeamStart;
+uniform vec2 uBeamEnd;
+uniform float uBeamWidth; // relative to min(res)
+uniform float uFogAmount;
+
+float sdSegment(vec2 p, vec2 a, vec2 b) {
+  vec2 pa = p - a;
+  vec2 ba = b - a;
+  float h = clamp(dot(pa, ba) / dot(ba, ba), 0.0, 1.0);
+  return length(pa - ba * h);
+}
+
+float hash(vec2 p) { return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123); }
+float noise(vec2 p) {
+  vec2 i = floor(p);
+  vec2 f = fract(p);
+  float a = hash(i);
+  float b = hash(i + vec2(1.0, 0.0));
+  float c = hash(i + vec2(0.0, 1.0));
+  float d = hash(i + vec2(1.0, 1.0));
+  vec2 u = f * f * (3.0 - 2.0 * f);
+  return mix(a, b, u.x) + (c - a) * u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
+}
+
+void main() {
+  vec2 res = uResolution;
+  vec2 p = vUv * res;
+  vec2 a = uBeamStart * res;
+  vec2 b = uBeamEnd * res;
+  float d = sdSegment(p, a, b);
+
+  float minDim = min(res.x, res.y);
+  float halfW = uBeamWidth * minDim * 0.5;
+  float beam = smoothstep(halfW, 0.0, d);
+
+  vec2 dir = normalize(b - a + 1e-5);
+  vec2 ortho = vec2(-dir.y, dir.x);
+  float t = uTime * 0.08;
+  float fogLine = dot((p - a), dir) / length(b - a);
+  float fogDist = dot((p - a), ortho);
+  float fogBase = noise(vec2(fogLine * 4.0 + t, fogDist * 0.02 - t)) * 0.6 + 0.4;
+  float fog = fogBase * uFogAmount;
+
+  float alpha = (beam * uIntensity * 0.9 + fog * 0.35) * uAlpha;
+  vec2 q = vUv * (1.0 - vUv);
+  float vignette = pow(q.x * q.y * 4.0, 0.25);
+  alpha *= vignette + 0.4;
+
+  outColor = vec4(uColor, alpha);
+}
+`;
+
+export function RedBeamBackground({
+  className,
+  style,
+  color = "#FF4444",
+  intensity = 0.9,
+  mouseTiltStrength = 0,
+  performance,
+}: RedBeamBackgroundProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const stoppedRef = useRef(false);
+
+  const perf = useMemo(
+    () => ({
+      minFps: performance?.minFps ?? 50,
+      maxFps: performance?.maxFps ?? 58,
+      dprFloor: performance?.dprFloor ?? 0.6,
+    }),
+    [performance]
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!supportsWebGL()) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const renderer = new THREE.WebGLRenderer({ antialias: false, alpha: true, powerPreference: "high-performance" });
+    renderer.setClearColor(0x000000, 0);
+    renderer.autoClear = true;
+    renderer.setPixelRatio(Math.max(perf.dprFloor, Math.min(window.devicePixelRatio || 1, 1)));
+
+    const canvas = renderer.domElement;
+    canvas.setAttribute("aria-hidden", "true");
+    canvas.style.width = "100%";
+    canvas.style.height = "100%";
+    canvas.style.display = "block";
+    canvas.style.pointerEvents = "none";
+    container.appendChild(canvas);
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+
+    const geometry = createFullscreenTriangle();
+
+    const mat = new THREE.RawShaderMaterial({
+      vertexShader,
+      fragmentShader,
+      transparent: true,
+      depthWrite: false,
+      depthTest: false,
+      uniforms: {
+        uTime: { value: 0 },
+        uResolution: { value: new THREE.Vector2(1, 1) },
+        uColor: { value: new THREE.Color(color) },
+        uIntensity: { value: intensity },
+        uAlpha: { value: 0.7 },
+        uBeamStart: { value: new THREE.Vector2(0.35, -0.15) },
+        uBeamEnd: { value: new THREE.Vector2(0.88, 0.55) },
+        uBeamWidth: { value: 0.0075 },
+        uFogAmount: { value: 0.75 },
+      },
+    });
+
+    const mesh = new THREE.Mesh(geometry, mat);
+    scene.add(mesh);
+
+    let animationId = 0;
+    let lastTime = now();
+    let lastFpsCheck = lastTime;
+    let frames = 0;
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        stoppedRef.current = !entry.isIntersecting;
+      },
+      { threshold: 0 }
+    );
+    io.observe(container);
+
+    const onResize = () => {
+      const { clientWidth, clientHeight } = container;
+      renderer.setSize(clientWidth, clientHeight, false);
+      (mat.uniforms.uResolution.value as THREE.Vector2).set(clientWidth, clientHeight);
+    };
+
+    const onVisibility = () => {
+      if (document.hidden) {
+        stoppedRef.current = true;
+      } else {
+        stoppedRef.current = false;
+        lastTime = now();
+        lastFpsCheck = lastTime;
+        frames = 0;
+        loop();
+      }
+    };
+
+    const onContextLost = (e: Event) => {
+      e.preventDefault();
+      stoppedRef.current = true;
+    };
+
+    canvas.addEventListener("webglcontextlost", onContextLost as EventListener, false);
+
+    window.addEventListener("resize", onResize);
+    document.addEventListener("visibilitychange", onVisibility);
+
+    onResize();
+
+    const isDark = document.documentElement.classList.contains("dark");
+    (mat.uniforms.uAlpha as any).value = isDark ? 0.7 : 0.55;
+
+    let tiltX = 0, tiltY = 0;
+    const handleMouse = (e: MouseEvent) => {
+      if (mouseTiltStrength <= 0) return;
+      const rect = container.getBoundingClientRect();
+      const cx = rect.left + rect.width / 2;
+      const cy = rect.top + rect.height / 2;
+      tiltX = ((e.clientY - cy) / rect.height) * mouseTiltStrength;
+      tiltY = ((e.clientX - cx) / rect.width) * mouseTiltStrength;
+      const baseStart = new THREE.Vector2(0.35, -0.15);
+      const baseEnd = new THREE.Vector2(0.88, 0.55);
+      (mat.uniforms.uBeamStart.value as THREE.Vector2).set(baseStart.x + tiltX * 0.03, baseStart.y + tiltY * 0.03);
+      (mat.uniforms.uBeamEnd.value as THREE.Vector2).set(baseEnd.x + tiltY * 0.02, baseEnd.y + tiltX * 0.02);
+    };
+    window.addEventListener("mousemove", handleMouse);
+
+    function now() { return (typeof performance !== "undefined" ? performance.now() : Date.now()); }
+
+    const loop = () => {
+      if (stoppedRef.current) {
+        animationId = requestAnimationFrame(loop);
+        return;
+      }
+
+      const _now = now();
+      const dt = (_now - lastTime) / 1000;
+      lastTime = _now;
+
+      frames++;
+      if (_now - lastFpsCheck > 1000) {
+        const fps = (frames * 1000) / (_now - lastFpsCheck);
+        frames = 0;
+        lastFpsCheck = _now;
+        const currentPR = renderer.getPixelRatio();
+        if (fps < perf.minFps && currentPR > perf.dprFloor) {
+          renderer.setPixelRatio(Math.max(perf.dprFloor, currentPR - 0.1));
+          onResize();
+        } else if (fps > perf.maxFps && currentPR < (window.devicePixelRatio || 1)) {
+          renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, currentPR + 0.1));
+          onResize();
+        }
+      }
+
+      (mat.uniforms.uTime as any).value += dt;
+      renderer.render(scene, camera);
+      animationId = requestAnimationFrame(loop);
+    };
+
+    loop();
+
+    return () => {
+      cancelAnimationFrame(animationId);
+      io.disconnect();
+      window.removeEventListener("resize", onResize);
+      window.removeEventListener("mousemove", handleMouse);
+      document.removeEventListener("visibilitychange", onVisibility);
+      canvas.removeEventListener("webglcontextlost", onContextLost as EventListener);
+
+      geometry.dispose();
+      (mat as THREE.Material).dispose();
+      renderer.dispose();
+      if (canvas.parentElement === container) container.removeChild(canvas);
+    };
+  }, [color, intensity, mouseTiltStrength, perf.dprFloor, perf.maxFps, perf.minFps]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={["pointer-events-none absolute inset-0 z-0", className || ""].join(" ")}
+      style={style}
+      aria-hidden="true"
+    />
+  );
+}
+
+export default RedBeamBackground;

--- a/packages/ui/src/components/red-beam-background.tsx
+++ b/packages/ui/src/components/red-beam-background.tsx
@@ -117,18 +117,18 @@ export function RedBeamBackground({
   color = "#FF4444",
   intensity = 0.9,
   mouseTiltStrength = 0,
-  performance,
+  performance: perfOptions,
 }: RedBeamBackgroundProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const stoppedRef = useRef(false);
 
   const perf = useMemo(
     () => ({
-      minFps: performance?.minFps ?? 50,
-      maxFps: performance?.maxFps ?? 58,
-      dprFloor: performance?.dprFloor ?? 0.6,
+      minFps: perfOptions?.minFps ?? 50,
+      maxFps: perfOptions?.maxFps ?? 58,
+      dprFloor: perfOptions?.dprFloor ?? 0.6,
     }),
-    [performance]
+    [perfOptions]
   );
 
   useEffect(() => {
@@ -239,7 +239,12 @@ export function RedBeamBackground({
     };
     window.addEventListener("mousemove", handleMouse);
 
-    function now() { return (typeof performance !== "undefined" ? performance.now() : Date.now()); }
+    function now() {
+      if (typeof window !== "undefined" && window.performance && typeof window.performance.now === "function") {
+        return window.performance.now();
+      }
+      return Date.now();
+    }
 
     const loop = () => {
       if (stoppedRef.current) {


### PR DESCRIPTION
### Summary
Adds a new animated background option “Red Abanalka” — a subtle red beam with a wisp fog — that renders behind the AI_Prompt on the home (new chat) view only. The effect is lightweight (single fullscreen shader), SSR-safe, and disabled on mobile (<768px) for performance.

### Changes
- UI: New component `RedBeamBackground` (Three.js RawShaderMaterial, alpha pipeline, decorative-only)
- Preferences: Extend background variant to include `red-beam` and persist selection
- Settings: Add "Red Abanalka" option in Personalization → Background style (i18n en/fr)
- Chat input: Inject `RedBeamBackground` behind AI_Prompt on home page only; maintain proper z-index
- UI package: Add dependency `three@^0.163.0` and export the new component

### Why
- Provide a tasteful, on-brand animated background option focused around the AI prompt area, while keeping readability and performance in check.

### Behavior
- Home (no currentThreadId): shows the red beam + fog behind the prompt (enters from top, ends toward right side of prompt area)
- Thread pages: unchanged (no beam)
- Mobile (<768px): hidden (`hidden md:block`)
- Light/Dark: same red (#FF4444), with a slightly reduced alpha in light mode for contrast

### Reliability & Perf
- Graceful WebGL capability detection and cleanup on unmount
- Throttles and dynamically scales DPR to maintain ~50–58 FPS
- Suspends when tab is hidden and when out of viewport (IntersectionObserver)
- Transparent renderer; does not intercept pointer events; aria-hidden

### Files
- packages/ui/src/components/red-beam-background.tsx
- packages/ui/src/components/index.ts (export)
- packages/ui/package.json (add three)
- packages/common/store/preferences.store.ts (add 'red-beam')
- packages/common/components/settings-modal.tsx (add option)
- packages/common/i18n/en.json, fr.json (labels)
- packages/common/components/chat-input/animated-input.tsx (inject + z-index)

### Notes
- Kept background color constant across themes per request; only alpha slightly reduced on light mode.
- Z-index: background at z-0; prompt container at z-10.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/572af696-84af-11f0-a94e-3eef481a796b/task/40ca9ea7-3dec-4b67-a80c-6b8b070225a9))