### PR TITLE
Hide top overlay on /chat home; keep on threads

### DIFF
--- a/packages/common/components/layout/root.tsx
+++ b/packages/common/components/layout/root.tsx
@@ -33,6 +33,7 @@ export const RootLayout: FC<TRootLayout> = ({ children }) => {
 
     const pathname = usePathname();
     const isChat = pathname.startsWith('/chat');
+    const isChatHome = pathname === '/chat';
 
     useEffect(() => {
         plausible.trackPageview();
@@ -76,7 +77,9 @@ export const RootLayout: FC<TRootLayout> = ({ children }) => {
                         <div id="main-content" className={cn(containerClass, isChat && 'chat-theme')} role="main">
                             <div className="relative flex h-full w-0 flex-1 flex-row">
                                 <div className="flex w-full flex-col gap-2 overflow-y-auto">
-                                    <div className="from-secondary to-secondary/0 via-secondary/70 absolute left-0 right-0 top-0 z-40 flex flex-row items-center justify-center gap-1 bg-gradient-to-b p-2 pb-12"></div>
+                                    {!isChatHome && (
+                                        <div className="from-secondary to-secondary/0 via-secondary/70 absolute left-0 right-0 top-0 z-40 flex flex-row items-center justify-center gap-1 bg-gradient-to-b p-2 pb-12"></div>
+                                    )}
                                     {/* Auth Button Header */}
 
                                     {children}


### PR DESCRIPTION
Summary
- Hide the top gradient overlay on the chat home (/chat) to prevent text appearing “faded” when scrolling.
- Keep the overlay on thread pages (/chat/[id]) and all other routes, per request.

Changes
- packages/common/components/layout/root.tsx: Add pathname check (isChatHome) and conditionally render the top overlay only when not on /chat.

Impact
- Improves readability on /chat when the user scrolls.
- No functional changes to other pages; overlay remains available on /chat/[id].

Testing
- Visit /chat: The top overlay should be hidden and text should not fade under a veil when scrolling.
- Create/open a thread (navigate to /chat/[id]): The top overlay should still be present as before.
