### PR TITLE
Add 'Shader animation' background (Three.js) for /chat index (opt-in)

### DIFF
--- a/packages/common/components/settings-modal.tsx
+++ b/packages/common/components/settings-modal.tsx
@@ -535,8 +535,9 @@ export const PersonalizationSettings = () => {
                     <option value="new">{t('settings.personalization.background.new')}</option>
                     <option value="old">{t('settings.personalization.background.old')}</option>
                     <option value="mesh">{t('settings.personalization.background.mesh')}</option>
+                    <option value="shader">{t('settings.personalization.background.shader')}</option>
                 </select>
-                {backgroundVariant !== 'mesh' && (
+                {(backgroundVariant === 'new' || backgroundVariant === 'old') && (
                     <p className="text-muted-foreground text-xs">Actif uniquement en mode sombre</p>
                 )}
             </div>

--- a/packages/common/i18n/en.json
+++ b/packages/common/i18n/en.json
@@ -50,6 +50,7 @@
   "settings.personalization.background.new": "New",
   "settings.personalization.background.old": "Old",
   "settings.personalization.background.mesh": "Mesh shader",
+  "settings.personalization.background.shader": "Shader animation",
   "settings.personalization.shine.title": "Shine border colors",
   "settings.personalization.shine.description": "Choose a 3‑color preset for the animated chat input border.",
   "settings.personalization.shine.palette1": "Palette 1",

--- a/packages/common/i18n/fr.json
+++ b/packages/common/i18n/fr.json
@@ -50,6 +50,7 @@
   "settings.personalization.background.new": "Nouveau",
   "settings.personalization.background.old": "Ancien",
   "settings.personalization.background.mesh": "Mesh shader",
+  "settings.personalization.background.shader": "Shader animation",
   "settings.personalization.shine.title": "Couleurs de la bordure lumineuse",
   "settings.personalization.shine.description": "Choisissez un préréglage de 3 couleurs pour la bordure animée de l’entrée de chat.",
   "settings.personalization.shine.palette1": "Palette 1",

--- a/packages/common/store/preferences.store.ts
+++ b/packages/common/store/preferences.store.ts
@@ -5,7 +5,7 @@ import { createJSONStorage, persist } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 import type { ShinePreset } from '@repo/shared/config';
 
-export type BackgroundVariant = 'new' | 'old' | 'mesh';
+export type BackgroundVariant = 'new' | 'old' | 'mesh' | 'shader';
 
 type PreferencesState = {
   backgroundVariant: BackgroundVariant;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,6 +20,7 @@
     "framer-motion": "^11.14.3",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.468.0",
+    "three": "^0.160.0",
     "tailwind-merge": "^2.0.0",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/packages/ui/src/components/grid-gradient-background.tsx
+++ b/packages/ui/src/components/grid-gradient-background.tsx
@@ -2,17 +2,21 @@
 import React from 'react';
 import { cn } from '../lib/utils';
 import { MeshShaderBackground } from './mesh-shader-background';
+import { ShaderAnimationBackground } from './shader-animation-background';
 
 type GridGradientBackgroundProps = {
   side?: 'left' | 'right';
   className?: string;
   style?: React.CSSProperties;
-  variant?: 'new' | 'old' | 'mesh';
+  variant?: 'new' | 'old' | 'mesh' | 'shader';
 };
 
 export function GridGradientBackground({ side = 'left', className, style, variant = 'new' }: GridGradientBackgroundProps) {
   if (variant === 'mesh') {
     return <MeshShaderBackground />;
+  }
+  if (variant === 'shader') {
+    return <ShaderAnimationBackground />;
   }
 
   const haloColor = 'rgba(139,92,246,0.25)';

--- a/packages/ui/src/components/shader-animation-background.tsx
+++ b/packages/ui/src/components/shader-animation-background.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import * as THREE from "three";
+
+export function ShaderAnimationBackground() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const sceneRef = useRef<{
+    camera: THREE.Camera;
+    scene: THREE.Scene;
+    renderer: THREE.WebGLRenderer;
+    uniforms: any;
+    animationId: number;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const container = containerRef.current;
+
+    const vertexShader = `
+      void main() {
+        gl_Position = vec4( position, 1.0 );
+      }
+    `;
+
+    const fragmentShader = `
+      #define TWO_PI 6.2831853072
+      #define PI 3.14159265359
+
+      precision highp float;
+      uniform vec2 resolution;
+      uniform float time;
+
+      void main(void) {
+        vec2 uv = (gl_FragCoord.xy * 2.0 - resolution.xy) / min(resolution.x, resolution.y);
+        float t = time*0.05;
+        float lineWidth = 0.002;
+
+        vec3 color = vec3(0.0);
+        for(int j = 0; j < 3; j++){
+          for(int i=0; i < 5; i++){
+            color[j] += lineWidth*float(i*i) / abs(fract(t - 0.01*float(j)+float(i)*0.01)*5.0 - length(uv) + mod(uv.x+uv.y, 0.2));
+          }
+        }
+        
+        gl_FragColor = vec4(color[0],color[1],color[2],1.0);
+      }
+    `;
+
+    const camera = new THREE.Camera();
+    camera.position.z = 1;
+
+    const scene = new THREE.Scene();
+    const geometry = new THREE.PlaneGeometry(2, 2);
+
+    const uniforms = {
+      time: { value: 1.0 },
+      resolution: { value: new THREE.Vector2() },
+    } as const;
+
+    const material = new THREE.ShaderMaterial({
+      uniforms: uniforms as any,
+      vertexShader: vertexShader,
+      fragmentShader: fragmentShader,
+    });
+
+    const mesh = new THREE.Mesh(geometry, material);
+    scene.add(mesh);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setPixelRatio(window.devicePixelRatio);
+
+    container.appendChild(renderer.domElement);
+
+    const onWindowResize = () => {
+      const width = container.clientWidth;
+      const height = container.clientHeight;
+      renderer.setSize(width, height);
+      (uniforms.resolution as any).value.x = renderer.domElement.width;
+      (uniforms.resolution as any).value.y = renderer.domElement.height;
+    };
+
+    onWindowResize();
+    window.addEventListener("resize", onWindowResize, false);
+
+    const animate = () => {
+      const animationId = requestAnimationFrame(animate);
+      (uniforms.time as any).value += 0.05;
+      renderer.render(scene, camera);
+
+      if (sceneRef.current) {
+        sceneRef.current.animationId = animationId;
+      }
+    };
+
+    sceneRef.current = {
+      camera,
+      scene,
+      renderer,
+      uniforms: uniforms as any,
+      animationId: 0,
+    };
+
+    animate();
+
+    return () => {
+      window.removeEventListener("resize", onWindowResize);
+
+      if (sceneRef.current) {
+        cancelAnimationFrame(sceneRef.current.animationId);
+
+        if (container && sceneRef.current.renderer.domElement) {
+          container.removeChild(sceneRef.current.renderer.domElement);
+        }
+
+        sceneRef.current.renderer.dispose();
+        geometry.dispose();
+        material.dispose();
+      }
+    };
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      className="absolute inset-0 w-full h-full pointer-events-none z-0"
+      style={{
+        background: "#000",
+        overflow: "hidden",
+      }}
+      aria-hidden="true"
+    />
+  );
+}

--- a/packages/ui/src/types/three.d.ts
+++ b/packages/ui/src/types/three.d.ts
@@ -1,0 +1,1 @@
+declare module 'three';


### PR DESCRIPTION
Summary
- Add a new background variant “Shader animation” based on Three.js fragment/vertex shaders. It is opt-in via Settings and only appears on the chat index (/chat). When a message is sent (navigating to /chat/[id]), it disappears.

Changes
- UI: New ShaderAnimationBackground client component (Three.js) — absolute, full-bleed, pointer-events-none, black background, continuous animation.
- Background manager: Extend GridGradientBackground to support variant shader and render ShaderAnimationBackground (no dark-only restriction).
- Preferences: Extend backgroundVariant to include shader (default remains new).
- Settings: Add “Shader animation” option in Personalization > Background.
- i18n: Add settings.personalization.background.shader (en/fr).
- Dependency: Add three to @repo/ui. Added a minimal local declaration to satisfy typechecking.

Scope
- Renders only on /chat index (uses the same guard as other backgrounds). Disappears on /chat/[id] when a message is sent.

Testing
- Select Settings → Personalization → Background → “Shader animation”.
- Open /chat: shader is visible and animates smoothly; interactions remain unaffected.
- Send a message: navigates to /chat/[id]; shader disappears.
- Works in both light and dark themes.
