### PR TITLE
Add 'Shader lines' Three.js background for /chat index (opt-in)

### DIFF
--- a/packages/common/components/settings-modal.tsx
+++ b/packages/common/components/settings-modal.tsx
@@ -538,6 +538,7 @@ export const PersonalizationSettings = () => {
                     <option value="shader">{t('settings.personalization.background.shader')}</option>
                     <option value="neural">{t('settings.personalization.background.neural')}</option>
                     <option value="redlines">{t('settings.personalization.background.redlines')}</option>
+                    <option value="shaderlines">{t('settings.personalization.background.shaderlines')}</option>
                 </select>
                 {(backgroundVariant === 'new' || backgroundVariant === 'old') && (
                     <p className="text-muted-foreground text-xs">Actif uniquement en mode sombre</p>

--- a/packages/common/components/settings-modal.tsx
+++ b/packages/common/components/settings-modal.tsx
@@ -537,6 +537,7 @@ export const PersonalizationSettings = () => {
                     <option value="mesh">{t('settings.personalization.background.mesh')}</option>
                     <option value="shader">{t('settings.personalization.background.shader')}</option>
                     <option value="neural">{t('settings.personalization.background.neural')}</option>
+                    <option value="redlines">{t('settings.personalization.background.redlines')}</option>
                 </select>
                 {(backgroundVariant === 'new' || backgroundVariant === 'old') && (
                     <p className="text-muted-foreground text-xs">Actif uniquement en mode sombre</p>

--- a/packages/common/i18n/en.json
+++ b/packages/common/i18n/en.json
@@ -52,6 +52,7 @@
   "settings.personalization.background.mesh": "Mesh shader",
   "settings.personalization.background.shader": "Shader animation",
   "settings.personalization.background.neural": "Neural noise",
+  "settings.personalization.background.redlines": "Red lines fog",
   "settings.personalization.shine.title": "Shine border colors",
   "settings.personalization.shine.description": "Choose a 3‑color preset for the animated chat input border.",
   "settings.personalization.shine.palette1": "Palette 1",

--- a/packages/common/i18n/en.json
+++ b/packages/common/i18n/en.json
@@ -53,6 +53,7 @@
   "settings.personalization.background.shader": "Shader animation",
   "settings.personalization.background.neural": "Neural noise",
   "settings.personalization.background.redlines": "Red lines fog",
+  "settings.personalization.background.shaderlines": "Shader lines",
   "settings.personalization.shine.title": "Shine border colors",
   "settings.personalization.shine.description": "Choose a 3‑color preset for the animated chat input border.",
   "settings.personalization.shine.palette1": "Palette 1",

--- a/packages/common/i18n/fr.json
+++ b/packages/common/i18n/fr.json
@@ -53,6 +53,7 @@
   "settings.personalization.background.shader": "Shader animation",
   "settings.personalization.background.neural": "Neural noise",
   "settings.personalization.background.redlines": "Lignes rouges (brume)",
+  "settings.personalization.background.shaderlines": "Lignes shader",
   "settings.personalization.shine.title": "Couleurs de la bordure lumineuse",
   "settings.personalization.shine.description": "Choisissez un préréglage de 3 couleurs pour la bordure animée de l’entrée de chat.",
   "settings.personalization.shine.palette1": "Palette 1",

--- a/packages/common/i18n/fr.json
+++ b/packages/common/i18n/fr.json
@@ -52,6 +52,7 @@
   "settings.personalization.background.mesh": "Mesh shader",
   "settings.personalization.background.shader": "Shader animation",
   "settings.personalization.background.neural": "Neural noise",
+  "settings.personalization.background.redlines": "Lignes rouges (brume)",
   "settings.personalization.shine.title": "Couleurs de la bordure lumineuse",
   "settings.personalization.shine.description": "Choisissez un préréglage de 3 couleurs pour la bordure animée de l’entrée de chat.",
   "settings.personalization.shine.palette1": "Palette 1",

--- a/packages/common/store/preferences.store.ts
+++ b/packages/common/store/preferences.store.ts
@@ -5,7 +5,7 @@ import { createJSONStorage, persist } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 import type { ShinePreset } from '@repo/shared/config';
 
-export type BackgroundVariant = 'new' | 'old' | 'mesh' | 'shader' | 'neural';
+export type BackgroundVariant = 'new' | 'old' | 'mesh' | 'shader' | 'neural' | 'redlines';
 
 type PreferencesState = {
   backgroundVariant: BackgroundVariant;

--- a/packages/common/store/preferences.store.ts
+++ b/packages/common/store/preferences.store.ts
@@ -5,7 +5,7 @@ import { createJSONStorage, persist } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 import type { ShinePreset } from '@repo/shared/config';
 
-export type BackgroundVariant = 'new' | 'old' | 'mesh' | 'shader' | 'neural' | 'redlines';
+export type BackgroundVariant = 'new' | 'old' | 'mesh' | 'shader' | 'neural' | 'redlines' | 'shaderlines';
 
 type PreferencesState = {
   backgroundVariant: BackgroundVariant;

--- a/packages/ui/src/components/grid-gradient-background.tsx
+++ b/packages/ui/src/components/grid-gradient-background.tsx
@@ -5,12 +5,13 @@ import { MeshShaderBackground } from './mesh-shader-background';
 import { ShaderAnimationBackground } from './shader-animation-background';
 import { NeuralNoiseBackground } from './neural-noise-background';
 import { RedLinesFogBackground } from './red-lines-fog-background';
+import { ShaderLinesBackground } from './shader-lines-background';
 
 type GridGradientBackgroundProps = {
   side?: 'left' | 'right';
   className?: string;
   style?: React.CSSProperties;
-  variant?: 'new' | 'old' | 'mesh' | 'shader' | 'neural' | 'redlines';
+  variant?: 'new' | 'old' | 'mesh' | 'shader' | 'neural' | 'redlines' | 'shaderlines';
 };
 
 export function GridGradientBackground({ side = 'left', className, style, variant = 'new' }: GridGradientBackgroundProps) {
@@ -25,6 +26,9 @@ export function GridGradientBackground({ side = 'left', className, style, varian
   }
   if (variant === 'redlines') {
     return <RedLinesFogBackground />;
+  }
+  if (variant === 'shaderlines') {
+    return <ShaderLinesBackground />;
   }
 
   const haloColor = 'rgba(139,92,246,0.25)';

--- a/packages/ui/src/components/grid-gradient-background.tsx
+++ b/packages/ui/src/components/grid-gradient-background.tsx
@@ -4,12 +4,13 @@ import { cn } from '../lib/utils';
 import { MeshShaderBackground } from './mesh-shader-background';
 import { ShaderAnimationBackground } from './shader-animation-background';
 import { NeuralNoiseBackground } from './neural-noise-background';
+import { RedLinesFogBackground } from './red-lines-fog-background';
 
 type GridGradientBackgroundProps = {
   side?: 'left' | 'right';
   className?: string;
   style?: React.CSSProperties;
-  variant?: 'new' | 'old' | 'mesh' | 'shader' | 'neural';
+  variant?: 'new' | 'old' | 'mesh' | 'shader' | 'neural' | 'redlines';
 };
 
 export function GridGradientBackground({ side = 'left', className, style, variant = 'new' }: GridGradientBackgroundProps) {
@@ -21,6 +22,9 @@ export function GridGradientBackground({ side = 'left', className, style, varian
   }
   if (variant === 'neural') {
     return <NeuralNoiseBackground />;
+  }
+  if (variant === 'redlines') {
+    return <RedLinesFogBackground />;
   }
 
   const haloColor = 'rgba(139,92,246,0.25)';

--- a/packages/ui/src/components/red-lines-fog-background.tsx
+++ b/packages/ui/src/components/red-lines-fog-background.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export function RedLinesFogBackground() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const gl = (canvas.getContext("webgl2") as WebGL2RenderingContext | null);
+    if (!gl) {
+      // WebGL2 required for this shader (uses out vec4)
+      return;
+    }
+
+    const vertexSource = `#version 300 es
+precision highp float;
+layout(location = 0) in vec2 a_position;
+out vec2 vUv;
+void main() {
+  vUv = 0.5 * (a_position + 1.0);
+  gl_Position = vec4(a_position, 0.0, 1.0);
+}`;
+
+    const fragmentSource = `#version 300 es
+precision highp float;
+
+uniform vec2 uResolution;
+uniform float uTime;
+uniform vec3 uColor;
+
+in vec2 vUv;
+out vec4 fragColor;
+
+float g(float v){return sqrt(clamp(v,0.0,1.0));}
+
+float beam(vec2 uv,float d,float w,float power){
+  float dist=length(uv);
+  return pow(clamp(1.0-abs(dist-d)/w,0.0,1.0),power);
+}
+
+void main() {
+  vec2 frag=gl_FragCoord.xy;
+  vec2 uv=frag/uResolution.xy;
+  vec2 uvc=2.0*uv-1.0;
+  uvc.x*=uResolution.x/uResolution.y;
+
+  // downward movement
+  uvc.y-=uTime*0.5;
+
+  float topA = exp(-6.0*abs(uvc.y+0.8));
+  float a = beam(uvc*0.9, 0.2, 0.6, 1.0);
+  float b = beam(uvc*1.2, 0.4, 0.6, 1.0);
+  float L = a + b*topA;
+
+  // fog
+  float fog=0.0;
+  float mv = uTime*0.2;
+  float lv = (2.0*uv.y+0.8-0.5)*4.0;
+  vec2 muv=uv*mat2(0.8,0.6,-0.6,0.8);
+  fog+=smoothstep(0.0,1.0,0.5+0.5*
+    cos(muv.y*20.0+cos(muv.x*5.0+mv*0.5)+mv+lv));
+
+  float LF=L+fog;
+  float tone=g(LF);
+  vec3 col=tone*uColor;
+  float alpha=clamp(tone,0.0,1.0);
+
+  fragColor = vec4(col,alpha);
+}`;
+
+    const compile = (type: number, source: string) => {
+      const sh = gl.createShader(type)!;
+      gl.shaderSource(sh, source);
+      gl.compileShader(sh);
+      if (!gl.getShaderParameter(sh, gl.COMPILE_STATUS)) {
+        console.error("Shader compile error:\n", gl.getShaderInfoLog(sh));
+        gl.deleteShader(sh);
+        return null;
+      }
+      return sh;
+    };
+
+    const vs = compile(gl.VERTEX_SHADER, vertexSource);
+    const fs = compile(gl.FRAGMENT_SHADER, fragmentSource);
+    if (!vs || !fs) return;
+
+    const program = gl.createProgram()!;
+    gl.attachShader(program, vs);
+    gl.attachShader(program, fs);
+    gl.linkProgram(program);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      console.error("Program link error:\n", gl.getProgramInfoLog(program));
+      return;
+    }
+    gl.useProgram(program);
+
+    // Fullscreen quad
+    const vertices = new Float32Array([
+      -1, -1,
+       1, -1,
+      -1,  1,
+       1,  1,
+    ]);
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);
+
+    const aPos = gl.getAttribLocation(program, "a_position");
+    gl.enableVertexAttribArray(aPos);
+    gl.vertexAttribPointer(aPos, 2, gl.FLOAT, false, 0, 0);
+
+    const uResolution = gl.getUniformLocation(program, "uResolution");
+    const uTime = gl.getUniformLocation(program, "uTime");
+    const uColor = gl.getUniformLocation(program, "uColor");
+
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    const resize = () => {
+      const rect = canvas.getBoundingClientRect();
+      const width = Math.max(1, Math.floor(rect.width * dpr));
+      const height = Math.max(1, Math.floor(rect.height * dpr));
+      if (canvas.width !== width || canvas.height !== height) {
+        canvas.width = width;
+        canvas.height = height;
+      }
+      gl.viewport(0, 0, width, height);
+      if (uResolution) gl.uniform2f(uResolution, width, height);
+    };
+
+    // Red color with slight softness
+    if (uColor) gl.uniform3f(uColor, 1.0, 0.2, 0.2);
+
+    const start = performance.now();
+    const render = () => {
+      rafRef.current = requestAnimationFrame(render);
+      const t = (performance.now() - start) * 0.001; // seconds
+      if (uTime) gl.uniform1f(uTime, t);
+      gl.clearColor(0,0,0,0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+    };
+
+    const onResize = () => resize();
+    window.addEventListener("resize", onResize);
+    resize();
+    render();
+
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      window.removeEventListener("resize", onResize);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="absolute inset-0 w-full h-full pointer-events-none z-0"
+      aria-hidden="true"
+    />
+  );
+}

--- a/packages/ui/src/components/shader-lines-background.tsx
+++ b/packages/ui/src/components/shader-lines-background.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import * as THREE from "three";
+
+export function ShaderLinesBackground() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const sceneRef = useRef<{
+    camera: THREE.Camera;
+    scene: THREE.Scene;
+    renderer: THREE.WebGLRenderer;
+    uniforms: Record<string, any>;
+    animationId: number | null;
+  } | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    // Clear container if re-mounted
+    container.innerHTML = "";
+
+    const camera = new THREE.Camera();
+    camera.position.z = 1;
+
+    const scene = new THREE.Scene();
+    const geometry = new THREE.PlaneGeometry(2, 2);
+
+    const uniforms = {
+      time: { value: 1.0 },
+      resolution: { value: new THREE.Vector2() },
+    };
+
+    const vertexShader = `
+      void main() {
+        gl_Position = vec4( position, 1.0 );
+      }
+    `;
+
+    const fragmentShader = `
+      #define TWO_PI 6.2831853072
+      #define PI 3.14159265359
+
+      precision highp float;
+      uniform vec2 resolution;
+      uniform float time;
+
+      float random (in float x) {
+        return fract(sin(x)*1e4);
+      }
+      float random (vec2 st) {
+        return fract(sin(dot(st.xy, vec2(12.9898,78.233)))*43758.5453123);
+      }
+
+      void main(void) {
+        vec2 uv = (gl_FragCoord.xy * 2.0 - resolution.xy) / min(resolution.x, resolution.y);
+        vec2 fMosaicScal = vec2(4.0, 2.0);
+        vec2 vScreenSize = vec2(256.0, 256.0);
+        uv.x = floor(uv.x * vScreenSize.x / fMosaicScal.x) / (vScreenSize.x / fMosaicScal.x);
+        uv.y = floor(uv.y * vScreenSize.y / fMosaicScal.y) / (vScreenSize.y / fMosaicScal.y);
+
+        float t = time*0.06 + random(uv.x)*0.4;
+        float lineWidth = 0.0008;
+
+        vec3 color = vec3(0.0);
+        for(int j = 0; j < 3; j++){
+          for(int i = 0; i < 5; i++){
+            color[j] += lineWidth*float(i*i) / abs(fract(t - 0.01*float(j)+float(i)*0.01)*1.0 - length(uv));
+          }
+        }
+        gl_FragColor = vec4(color.b,color.g,color.r,1.0);
+      }
+    `;
+
+    const material = new THREE.ShaderMaterial({
+      uniforms,
+      vertexShader,
+      fragmentShader,
+    });
+
+    const mesh = new THREE.Mesh(geometry, material);
+    scene.add(mesh);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setPixelRatio(window.devicePixelRatio || 1);
+    container.appendChild(renderer.domElement);
+
+    const onResize = () => {
+      const rect = container.getBoundingClientRect();
+      const width = Math.max(1, Math.floor(rect.width));
+      const height = Math.max(1, Math.floor(rect.height));
+      renderer.setSize(width, height, false);
+      uniforms.resolution.value.x = renderer.domElement.width;
+      uniforms.resolution.value.y = renderer.domElement.height;
+    };
+
+    onResize();
+    window.addEventListener("resize", onResize);
+
+    const animate = () => {
+      const id = requestAnimationFrame(animate);
+      if (sceneRef.current) sceneRef.current.animationId = id;
+      uniforms.time.value += 0.05;
+      renderer.render(scene, camera);
+    };
+
+    sceneRef.current = { camera, scene, renderer, uniforms, animationId: null };
+    animate();
+
+    return () => {
+      window.removeEventListener("resize", onResize);
+      if (sceneRef.current?.animationId) cancelAnimationFrame(sceneRef.current.animationId);
+      try {
+        container.removeChild(renderer.domElement);
+      } catch {}
+      renderer.dispose();
+      geometry.dispose();
+      material.dispose();
+    };
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      className="absolute inset-0 w-full h-full pointer-events-none z-0"
+      aria-hidden="true"
+    />
+  );
+}


### PR DESCRIPTION
Summary
- Add a new background variant “Shader lines” (Three.js) as an opt‑in personalization. It renders only on /chat (index) and disappears on /chat/[id] when a message is sent.

Changes
- UI: New ShaderLinesBackground client component with the provided fragment shader effect (mosaic + radial lines), absolute full‑bleed, pointer‑events‑none.
- Background manager: Extend GridGradientBackground to support shaderlines and render ShaderLinesBackground (no dark‑only restriction).
- Preferences: Extend backgroundVariant to include shaderlines (default unchanged).
- Settings: Add “Shader lines” option to Personalization > Background.
- i18n: Add settings.personalization.background.shaderlines to en/fr.

Scope & Behavior
- Renders only on /chat home (keeps parity with other custom backgrounds). Disappears on /chat/[id].

Testing
- Settings → Personalization → Background → “Shader lines”. Open /chat: effect is visible and animates; create/send a message to /chat/[id]: effect is not rendered.
