### PR TITLE
Verrouillage après 3 échecs + Rate limiting + Journalisation

### DIFF
--- a/apps/web/app/api/admin/users/[id]/unlock/route.ts
+++ b/apps/web/app/api/admin/users/[id]/unlock/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@repo/prisma';
+import { requireAdmin } from '@/app/api/_lib/auth';
+import { ActivityAction } from '@prisma/client';
+import { geolocation } from '@vercel/functions';
+import { getIp } from '@/app/api/completion/utils';
+
+export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+  const admin = await requireAdmin(request);
+  const id = params.id;
+
+  const user = await prisma.user.findUnique({ where: { id } });
+  if (!user) return NextResponse.json({ error: 'Utilisateur introuvable' }, { status: 404 });
+
+  const gl = geolocation(request);
+  const ip = getIp(request);
+
+  await prisma.$transaction([
+    prisma.user.update({
+      where: { id },
+      data: {
+        failedLoginAttempts: 0,
+        isLocked: false,
+        lockedAt: null,
+        lockReason: null,
+      },
+    }),
+    prisma.activityLog.create({
+      data: {
+        userId: id,
+        actorId: admin.userId,
+        action: ActivityAction.unlock,
+        details: user.lockReason ? { previousLockReason: user.lockReason } : undefined,
+        ip: ip ?? undefined,
+        country: gl?.country ?? undefined,
+        region: gl?.region ?? undefined,
+        city: gl?.city ?? undefined,
+      },
+    }),
+  ]);
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/app/api/admin/users/route.ts
+++ b/apps/web/app/api/admin/users/route.ts
@@ -42,6 +42,7 @@ export async function GET(request: NextRequest) {
         email: u.email,
         role: u.role,
         isSuspended: u.isSuspended,
+        isLocked: (u as any).isLocked ?? false,
         createdAt: u.createdAt,
         lastSeen: s?.lastSeen ?? null,
         lastIp: s?.lastIp ?? null,

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@repo/prisma';
-import { createSessionForUser } from '@/app/api/_lib/auth';
+import { createSessionForUser, getIp } from '@/app/api/_lib/auth';
 import bcrypt from 'bcryptjs';
 import { ActivityAction } from '@prisma/client';
 import { geolocation } from '@vercel/functions';
-import { getIp } from '@/app/api/completion/utils';
+
+const LOCK_MESSAGE = 'Votre compte a été désactivé après 3 tentatives incorrectes. Pour le réactiver, contactez l’administrateur.';
+const RATE_LIMIT_MESSAGE = 'Trop de tentatives, réessayez dans une minute.';
 
 export async function POST(request: NextRequest) {
   const { email, password } = await request.json().catch(() => ({}));
@@ -12,17 +14,113 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Email et mot de passe requis' }, { status: 400 });
   }
 
-  const user = await prisma.user.findUnique({ where: { email } });
-  if (!user) return NextResponse.json({ error: 'Identifiants invalides' }, { status: 401 });
-  if (user.isSuspended) return NextResponse.json({ error: 'Compte suspendu' }, { status: 403 });
-
-  const ok = await bcrypt.compare(password, user.passwordHash);
-  if (!ok) return NextResponse.json({ error: 'Identifiants invalides' }, { status: 401 });
-
-  const { token, expiresAt } = await createSessionForUser(user.id, request);
-
   const gl = geolocation(request);
   const ip = getIp(request);
+
+  await prisma.activityLog.create({
+    data: {
+      action: ActivityAction.login_attempt,
+      ip: ip ?? undefined,
+      country: gl?.country ?? undefined,
+      region: gl?.region ?? undefined,
+      city: gl?.city ?? undefined,
+      details: { email }
+    },
+  });
+
+  if (ip) {
+    const since = new Date(Date.now() - 60_000);
+    const attempts = await prisma.activityLog.count({
+      where: {
+        action: ActivityAction.login_attempt,
+        ip,
+        createdAt: { gte: since },
+      },
+    });
+    if (attempts > 5) {
+      return NextResponse.json({ error: RATE_LIMIT_MESSAGE }, { status: 429 });
+    }
+  }
+
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) {
+    await prisma.activityLog.create({
+      data: {
+        action: ActivityAction.login_failed,
+        details: { email },
+        ip: ip ?? undefined,
+        country: gl?.country ?? undefined,
+        region: gl?.region ?? undefined,
+        city: gl?.city ?? undefined,
+      },
+    });
+    return NextResponse.json({ error: 'Identifiants invalides' }, { status: 401 });
+  }
+
+  if (user.isSuspended) {
+    return NextResponse.json({ error: 'Compte suspendu' }, { status: 403 });
+  }
+
+  if (user.isLocked) {
+    return NextResponse.json({ errorCode: 'LOCKED', error: LOCK_MESSAGE }, { status: 403 });
+  }
+
+  const ok = await bcrypt.compare(password, user.passwordHash);
+  if (!ok) {
+    const result = await prisma.$transaction(async (tx) => {
+      const updated = await tx.user.update({
+        where: { id: user.id },
+        data: { failedLoginAttempts: { increment: 1 } },
+        select: { failedLoginAttempts: true, isLocked: true },
+      });
+
+      await tx.activityLog.create({
+        data: {
+          userId: user.id,
+          actorId: user.id,
+          action: ActivityAction.login_failed,
+          ip: ip ?? undefined,
+          country: gl?.country ?? undefined,
+          region: gl?.region ?? undefined,
+          city: gl?.city ?? undefined,
+        },
+      });
+
+      let lockedNow = false;
+      if (updated.failedLoginAttempts >= 3 && !updated.isLocked) {
+        await tx.user.update({
+          where: { id: user.id },
+          data: { isLocked: true, lockedAt: new Date(), lockReason: 'lockout_3_attempts' },
+        });
+        await tx.activityLog.create({
+          data: {
+            userId: user.id,
+            actorId: user.id,
+            action: ActivityAction.lockout,
+            details: { reason: 'lockout_3_attempts' },
+            ip: ip ?? undefined,
+            country: gl?.country ?? undefined,
+            region: gl?.region ?? undefined,
+            city: gl?.city ?? undefined,
+          },
+        });
+        lockedNow = true;
+      }
+
+      return { failedLoginAttempts: updated.failedLoginAttempts, lockedNow };
+    });
+
+    if (result.lockedNow) {
+      return NextResponse.json({ errorCode: 'LOCKED', error: LOCK_MESSAGE }, { status: 403 });
+    }
+
+    return NextResponse.json({ error: 'Identifiants invalides' }, { status: 401 });
+  }
+
+  await prisma.user.update({ where: { id: user.id }, data: { failedLoginAttempts: 0 } });
+
+  await createSessionForUser(user.id, request);
+
   await prisma.activityLog.create({
     data: {
       userId: user.id,

--- a/packages/common/i18n/fr.json
+++ b/packages/common/i18n/fr.json
@@ -101,5 +101,7 @@
   "account.suspended.message": "Votre compte a été suspendu pour non-respect du règlement. Contactez l’administrateur.",
   "account.deleted.title": "Compte supprimé",
   "account.deleted.message": "Vous n’avez pas respecté le règlement. Votre compte a été supprimé. Contactez l’administrateur.",
-  "account.deleted.logoutIn": "Déconnexion dans {seconds}s…"
+  "account.deleted.logoutIn": "Déconnexion dans {seconds}s…",
+  "auth.locked.message": "Votre compte a été désactivé après 3 tentatives incorrectes. Pour le réactiver, contactez l’administrateur.",
+  "auth.rateLimited.message": "Trop de tentatives, réessayez dans une minute."
 }

--- a/packages/prisma/migrations/20250924011000_lockout_and_rate_limit/migration.sql
+++ b/packages/prisma/migrations/20250924011000_lockout_and_rate_limit/migration.sql
@@ -1,0 +1,16 @@
+-- AlterEnum: add new actions for authentication events
+ALTER TYPE "ActivityAction" ADD VALUE IF NOT EXISTS 'login_attempt';
+ALTER TYPE "ActivityAction" ADD VALUE IF NOT EXISTS 'login_failed';
+ALTER TYPE "ActivityAction" ADD VALUE IF NOT EXISTS 'lockout';
+ALTER TYPE "ActivityAction" ADD VALUE IF NOT EXISTS 'unlock';
+
+-- AlterTable: extend User with lockout fields
+ALTER TABLE "User"
+  ADD COLUMN "failedLoginAttempts" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "isLocked" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "lockedAt" TIMESTAMP(3),
+  ADD COLUMN "lockReason" TEXT;
+
+-- Indexes to improve rate limiting and audit queries
+CREATE INDEX IF NOT EXISTS "ActivityLog_ip_idx" ON "ActivityLog"("ip");
+CREATE INDEX IF NOT EXISTS "ActivityLog_action_idx" ON "ActivityLog"("action");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -24,16 +24,24 @@ enum ActivityAction {
   delete
   account_created
   account_updated
+  login_attempt
+  login_failed
+  lockout
+  unlock
 }
 
 model User {
-  id           String   @id @default(cuid())
-  email        String   @unique
-  passwordHash String
-  role         Role     @default(user)
-  isSuspended  Boolean  @default(false)
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  id                   String   @id @default(cuid())
+  email                String   @unique
+  passwordHash         String
+  role                 Role     @default(user)
+  isSuspended          Boolean  @default(false)
+  failedLoginAttempts  Int      @default(0)
+  isLocked             Boolean  @default(false)
+  lockedAt             DateTime?
+  lockReason           String?
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
 
   sessions     Session[]
   activityLogs ActivityLog[] @relation("ActivityOnUser")
@@ -57,21 +65,23 @@ model Session {
 }
 
 model ActivityLog {
-  id       String          @id @default(cuid())
-  userId   String?
-  actorId  String?
-  action   ActivityAction
-  details  Json?
-  ip       String?
-  country  String?
-  region   String?
-  city     String?
-  createdAt DateTime       @default(now())
+  id        String          @id @default(cuid())
+  userId    String?
+  actorId   String?
+  action    ActivityAction
+  details   Json?
+  ip        String?
+  country   String?
+  region    String?
+  city      String?
+  createdAt DateTime        @default(now())
 
   user   User? @relation("ActivityOnUser", fields: [userId], references: [id], onDelete: SetNull)
   actor  User? @relation("ActivityByActor", fields: [actorId], references: [id], onDelete: SetNull)
 
   @@index([createdAt])
+  @@index([ip])
+  @@index([action])
 }
 
 model Feedback {


### PR DESCRIPTION
## Verrouillage après 3 échecs + Rate limiting + Journalisation

Cette PR implémente un verrouillage de compte après 3 tentatives de connexion échouées, un rate limiting IP (5 req/min) sur l’endpoint login, et une journalisation exhaustive des événements d’authentification.

Principales modifications
- Prisma
  - User: `failedLoginAttempts`, `isLocked`, `lockedAt`, `lockReason`.
  - ActivityAction: ajout de `login_attempt`, `login_failed`, `lockout`, `unlock`.
  - Indexes: `ActivityLog.ip`, `ActivityLog.action` (en plus de `createdAt`).
  - Migration ajoutée: `20250924011000_lockout_and_rate_limit`.
- API `/api/auth/login` (POST)
  - Enregistre `login_attempt` avant traitement.
  - Rate limiting IP: 5 req/min sur `login_attempt` (retourne 429 avec message FR générique).
  - Refus si `isSuspended` (403, message FR existant).
  - Refus si `isLocked` (403, code `LOCKED`, message explicite FR demandé).
  - Échec mot de passe: incrément de `failedLoginAttempts` en transaction, journalise `login_failed`, déclenche verrouillage à 3 avec `lockReason='lockout_3_attempts'` et journalise `lockout`.
  - Succès: réinitialise `failedLoginAttempts` à 0, crée la session, journalise `login`.
- API admin `/api/admin/users/[id]/unlock` (POST)
  - Protégée par `requireAdmin()`.
  - Réinitialise `failedLoginAttempts`, `isLocked`, `lockedAt`, `lockReason`.
  - Journalise `unlock` (avec `previousLockReason` dans `details`).
- UI Admin
  - Liste utilisateurs: affiche le statut `Verrouillé` quand `isLocked=true`.
  - Actions de ligne: bouton "Réactiver" (unlock) visible quand verrouillé, avec toast FR.
- i18n (FR)
  - `auth.locked.message`
  - `auth.rateLimited.message`

Pourquoi
- Réduire le risque de brute force, protéger les comptes, et fournir des traces d’audit complètes.
- Messages d’erreur explicites côté utilisateur et outillage d’admin pour réactiver rapidement.

Notes de déploiement
- Exécuter les migrations Prisma dans l’environnement (ex.: `prisma migrate deploy`).
- Aucun changement de contrat côté Front hors message d’erreur JSON (ajout éventuel de `errorCode: "LOCKED"`).

Critères d’acceptation couverts
- Verrouillage après 3 échecs, message FR explicite, journalisation `login_attempt`/`login_failed`/`lockout`/`login`/`unlock`.
- Déverrouillage par un administrateur depuis l’UI.
- Rate limiting IP 5 req/min sur login → 429 avec message générique FR.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/572a16e3-84af-11f0-a94e-3eef481a796b/task/7b281c14-0137-4030-a3a5-404f4b8e3ecf))