### PR TITLE
Force global UI background + Shine (admin-controlled, live updates)

### DIFF
--- a/apps/web/app/api/_lib/preferences-events.ts
+++ b/apps/web/app/api/_lib/preferences-events.ts
@@ -1,0 +1,27 @@
+import { EventEmitter } from 'events';
+
+export type UIPreferencesEvent = {
+  backgroundVariant: string;
+  aiPromptShinePreset: string;
+  updatedAt: string;
+};
+
+let emitter: EventEmitter | null = null;
+let latest: UIPreferencesEvent | null = null;
+
+export function getPreferencesEmitter() {
+  if (!emitter) {
+    emitter = new EventEmitter();
+    emitter.setMaxListeners(1000);
+  }
+  return emitter;
+}
+
+export function getLatestPreferencesEvent() {
+  return latest;
+}
+
+export function setLatestPreferencesEvent(evt: UIPreferencesEvent) {
+  latest = evt;
+  getPreferencesEmitter().emit('update', evt);
+}

--- a/apps/web/app/api/_lib/ui-preferences.ts
+++ b/apps/web/app/api/_lib/ui-preferences.ts
@@ -1,0 +1,34 @@
+import { prisma } from '@repo/prisma';
+
+export type UIPreferences = {
+  backgroundVariant: string;
+  aiPromptShinePreset: string;
+  updatedAt?: string;
+};
+
+export const DEFAULT_UI_PREFERENCES: UIPreferences = {
+  backgroundVariant: 'new',
+  aiPromptShinePreset: 'palette2',
+};
+
+export async function getUIPreferences(): Promise<UIPreferences> {
+  const existing = await (prisma as any).appSetting.findUnique({
+    where: { key: 'ui.preferences' },
+  });
+  if (!existing) {
+    return { ...DEFAULT_UI_PREFERENCES, updatedAt: new Date().toISOString() };
+  }
+  const value = existing.value || {};
+  const backgroundVariant = value.backgroundVariant || DEFAULT_UI_PREFERENCES.backgroundVariant;
+  const aiPromptShinePreset = value.aiPromptShinePreset || DEFAULT_UI_PREFERENCES.aiPromptShinePreset;
+  return { backgroundVariant, aiPromptShinePreset, updatedAt: existing.updatedAt?.toISOString?.() || new Date().toISOString() };
+}
+
+export async function upsertUIPreferences(value: { backgroundVariant: string; aiPromptShinePreset: string; }) {
+  const saved = await (prisma as any).appSetting.upsert({
+    where: { key: 'ui.preferences' },
+    update: { value },
+    create: { key: 'ui.preferences', value },
+  });
+  return { backgroundVariant: value.backgroundVariant, aiPromptShinePreset: value.aiPromptShinePreset, updatedAt: saved.updatedAt?.toISOString?.() || new Date().toISOString() } as UIPreferences;
+}

--- a/apps/web/app/api/admin/ui/preferences/route.ts
+++ b/apps/web/app/api/admin/ui/preferences/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/app/api/_lib/auth';
+import { z } from 'zod';
+import { upsertUIPreferences } from '@/app/api/_lib/ui-preferences';
+import { setLatestPreferencesEvent } from '@/app/api/_lib/preferences-events';
+import { prisma } from '@repo/prisma';
+import { ActivityAction } from '@prisma/client';
+import { geolocation } from '@vercel/functions';
+import { getIp } from '@/app/api/completion/utils';
+
+const schema = z.object({
+  backgroundVariant: z.enum(['new','old','mesh','shader','neural','redlines','shaderlines']),
+  aiPromptShinePreset: z.string(),
+});
+
+export async function POST(request: NextRequest) {
+  const admin = await requireAdmin(request);
+  const json = await request.json().catch(() => ({}));
+  const parsed = schema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+  const saved = await upsertUIPreferences(parsed.data);
+  const gl = geolocation(request);
+  const ip = getIp(request);
+  try {
+    await prisma.activityLog.create({
+      data: {
+        userId: undefined,
+        actorId: admin.userId,
+        action: ActivityAction.account_updated,
+        details: { uiPreferences: parsed.data },
+        ip: ip ?? undefined,
+        country: gl?.country ?? undefined,
+        region: gl?.region ?? undefined,
+        city: gl?.city ?? undefined,
+      },
+    });
+  } catch {}
+  setLatestPreferencesEvent({ backgroundVariant: saved.backgroundVariant, aiPromptShinePreset: saved.aiPromptShinePreset, updatedAt: saved.updatedAt! });
+  return NextResponse.json(saved);
+}

--- a/apps/web/app/api/ui/preferences/route.ts
+++ b/apps/web/app/api/ui/preferences/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { getUIPreferences } from '@/app/api/_lib/ui-preferences';
+
+export async function GET() {
+  const prefs = await getUIPreferences();
+  return NextResponse.json(prefs);
+}

--- a/apps/web/app/api/ui/stream/route.ts
+++ b/apps/web/app/api/ui/stream/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getUIPreferences } from '@/app/api/_lib/ui-preferences';
+import { getPreferencesEmitter, getLatestPreferencesEvent } from '@/app/api/_lib/preferences-events';
+
+const SSE_HEADERS = {
+  'Content-Type': 'text/event-stream',
+  'Cache-Control': 'no-cache, no-transform',
+  Connection: 'keep-alive',
+  'X-Accel-Buffering': 'no',
+} as const;
+
+export async function GET(request: NextRequest) {
+  const { readable, writable } = new TransformStream();
+  const encoder = new TextEncoder();
+  const writer = writable.getWriter();
+  const emit = (data: any) => writer.write(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+
+  const initial = getLatestPreferencesEvent() || (await getUIPreferences());
+  await emit(initial);
+
+  const emitter = getPreferencesEmitter();
+  const onUpdate = (data: any) => emit(data);
+  emitter.on('update', onUpdate);
+
+  const keepAlive = setInterval(() => {
+    writer.write(encoder.encode(`: ping\n\n`));
+  }, 25000);
+
+  request.signal.addEventListener('abort', () => {
+    clearInterval(keepAlive);
+    emitter.off('update', onUpdate);
+    try { writer.close(); } catch {}
+  });
+
+  return new NextResponse(readable as any, { headers: SSE_HEADERS });
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -17,6 +17,7 @@ import './globals.css';
 import { ThemeProvider } from 'next-themes';
 import { I18nProvider } from '@repo/common/i18n';
 import { OnlineHeartbeat, AccountStatusGate } from '@repo/common/components';
+import { GlobalPreferencesProvider } from '@repo/common/context/global-preferences-provider';
 
 export const metadata: Metadata = {
     title: 'HyperFix - développé pour L\'Hyper',
@@ -114,6 +115,7 @@ export default function ParentLayout({
                                         <RootLayout>{children}</RootLayout>
                                         <OnlineHeartbeat />
                                         <AccountStatusGate />
+                                        <GlobalPreferencesProvider />
                                     </ReactQueryProvider>
                                 </I18nProvider>
                             </TooltipProvider>

--- a/packages/common/components/chat-input/animated-input.tsx
+++ b/packages/common/components/chat-input/animated-input.tsx
@@ -17,7 +17,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useAgentStream } from '../../hooks/agent-provider';
 import { useApiKeysStore, useChatStore } from '../../store';
 import { ExamplePrompts } from '../exmaple-prompts';
-import { usePreferencesStore } from '@repo/common/store';
+import { useEffectivePreferences } from '@repo/common/hooks';
 import { NewIcon, ComingSoonIcon } from '../icons';
 import {
     IconAtom,
@@ -40,8 +40,7 @@ export const AnimatedChatInput = ({
     const { isSignedIn } = useAuth();
     const { user } = useUser();
     const { threadId: currentThreadId } = useParams();
-    const backgroundVariant = usePreferencesStore(state => state.backgroundVariant);
-    const aiPromptShinePreset = usePreferencesStore(state => state.aiPromptShinePreset);
+    const effective = useEffectivePreferences();
     const getThreadItems = useChatStore(state => state.getThreadItems);
     const threadItemsLength = useChatStore(useShallow(state => state.threadItems.length));
     const { handleSubmit } = useAgentStream();
@@ -386,7 +385,7 @@ export const AnimatedChatInput = ({
                             showWebToggle={!!(ChatModeConfig[chatMode]?.webSearch || hasApiKeyForChatMode(chatMode))}
                             webSearchEnabled={useWebSearch}
                             onToggleWebSearch={() => setUseWebSearch(!useWebSearch)}
-                            shineColors={getShineColors(aiPromptShinePreset)}
+                            shineColors={getShineColors(effective.aiPromptShinePreset)}
                         />
                     </ImageDropzoneRoot>
                 </Flex>
@@ -433,7 +432,7 @@ export const AnimatedChatInput = ({
                     : 'absolute inset-0 flex h-full w-full flex-col items-center justify-center'
             )}
         >
-            {!currentThreadId && <GridGradientBackground side="left" variant={backgroundVariant} />}
+            {!currentThreadId && <GridGradientBackground side="left" variant={effective.backgroundVariant} />}
             <div
                 className={cn(
                     'mx-auto flex w-full max-w-3xl flex-col items-start',

--- a/packages/common/components/chat-input/input.tsx
+++ b/packages/common/components/chat-input/input.tsx
@@ -12,7 +12,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { useParams, usePathname, useRouter } from 'next/navigation';
 import React, { useEffect } from 'react';
 import { useI18n } from '@repo/common/i18n';
-import { usePreferencesStore } from '@repo/common/store';
+import { useEffectivePreferences } from '@repo/common/hooks';
 import { v4 as uuidv4 } from 'uuid';
 import { useShallow } from 'zustand/react/shallow';
 import { useAgentStream } from '../../hooks/agent-provider';
@@ -53,7 +53,7 @@ export const ChatInput = ({
         },
     });
     const size = currentThreadId ? 'base' : 'sm';
-    const backgroundVariant = usePreferencesStore(state => state.backgroundVariant);
+    const effective = useEffectivePreferences();
     const getThreadItems = useChatStore(state => state.getThreadItems);
     const threadItemsLength = useChatStore(useShallow(state => state.threadItems.length));
     const { handleSubmit } = useAgentStream();
@@ -253,7 +253,7 @@ export const ChatInput = ({
                     : 'absolute inset-0 flex h-full w-full flex-col items-center justify-center'
             )}
         >
-            {!currentThreadId && <GridGradientBackground side="left" variant={backgroundVariant} />}
+            {!currentThreadId && <GridGradientBackground side="left" variant={effective.backgroundVariant} />}
             <div
                 className={cn(
                     'mx-auto flex w-full max-w-3xl flex-col items-start',

--- a/packages/common/context/global-preferences-provider.tsx
+++ b/packages/common/context/global-preferences-provider.tsx
@@ -1,0 +1,81 @@
+"use client";
+import { useEffect, useRef } from 'react';
+import { useGlobalPreferencesStore } from '@repo/common/store';
+
+async function fetchPreferences() {
+  try {
+    const res = await fetch('/api/ui/preferences', { cache: 'no-store' });
+    if (!res.ok) return null;
+    const json = await res.json();
+    return json as { backgroundVariant: string; aiPromptShinePreset: string; updatedAt?: string };
+  } catch {
+    return null;
+  }
+}
+
+export function GlobalPreferencesProvider() {
+  const setFromServer = useGlobalPreferencesStore(s => s.setFromServer);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const esRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    let stopped = false;
+    const startPolling = () => {
+      if (pollRef.current) return;
+      pollRef.current = setInterval(async () => {
+        const prefs = await fetchPreferences();
+        if (prefs) setFromServer(prefs as any);
+      }, 15000);
+      document.addEventListener('visibilitychange', onVisibility);
+    };
+    const stopPolling = () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+    const onVisibility = async () => {
+      if (document.visibilityState === 'visible') {
+        const prefs = await fetchPreferences();
+        if (prefs) setFromServer(prefs as any);
+      }
+    };
+
+    const init = async () => {
+      const prefs = await fetchPreferences();
+      if (prefs) setFromServer(prefs as any);
+      try {
+        const es = new EventSource('/api/ui/stream');
+        esRef.current = es;
+        es.onmessage = (evt) => {
+          try {
+            const data = JSON.parse(evt.data);
+            setFromServer(data);
+          } catch {}
+        };
+        es.onerror = () => {
+          es.close();
+          esRef.current = null;
+          startPolling();
+        };
+        es.onopen = () => {
+          stopPolling();
+        };
+      } catch {
+        startPolling();
+      }
+    };
+    init();
+    return () => {
+      stopped = true;
+      if (esRef.current) {
+        esRef.current.close();
+        esRef.current = null;
+      }
+      stopPolling();
+    };
+  }, [setFromServer]);
+
+  return null;
+}

--- a/packages/common/hooks/index.ts
+++ b/packages/common/hooks/index.ts
@@ -5,3 +5,4 @@ export * from './use-copy-text';
 export * from './use-editor';
 export * from './use-image-attachment';
 export * from './use-text-selection';
+export * from './use-effective-preferences';

--- a/packages/common/hooks/use-effective-preferences.ts
+++ b/packages/common/hooks/use-effective-preferences.ts
@@ -1,0 +1,15 @@
+"use client";
+import { useGlobalPreferencesStore } from '@repo/common/store/global-preferences.store';
+import { usePreferencesStore } from '@repo/common/store';
+
+export function useEffectivePreferences() {
+  const globalLoaded = useGlobalPreferencesStore(s => s.loaded);
+  const globalPrefs = useGlobalPreferencesStore(s => s.prefs);
+  const localBackground = usePreferencesStore(s => s.backgroundVariant);
+  const localShine = usePreferencesStore(s => s.aiPromptShinePreset);
+
+  if (globalLoaded && globalPrefs) {
+    return { backgroundVariant: globalPrefs.backgroundVariant, aiPromptShinePreset: globalPrefs.aiPromptShinePreset, updatedAt: globalPrefs.updatedAt } as const;
+  }
+  return { backgroundVariant: localBackground, aiPromptShinePreset: localShine } as const;
+}

--- a/packages/common/store/global-preferences.store.ts
+++ b/packages/common/store/global-preferences.store.ts
@@ -1,0 +1,34 @@
+"use client";
+import { create } from 'zustand';
+import type { BackgroundVariant } from './preferences.store';
+import type { ShinePreset } from '@repo/shared/config';
+
+export type GlobalPreferences = {
+  backgroundVariant: BackgroundVariant;
+  aiPromptShinePreset: ShinePreset;
+  updatedAt?: string;
+};
+
+type GlobalPreferencesState = {
+  loaded: boolean;
+  prefs?: GlobalPreferences;
+};
+
+type GlobalPreferencesActions = {
+  setFromServer: (prefs: GlobalPreferences) => void;
+};
+
+export const useGlobalPreferencesStore = create<GlobalPreferencesState & GlobalPreferencesActions>((set, get) => ({
+  loaded: false,
+  prefs: undefined,
+  setFromServer: (incoming) => {
+    const state = get();
+    const currentUpdatedAt = state.prefs?.updatedAt ? new Date(state.prefs.updatedAt).getTime() : 0;
+    const incomingUpdatedAt = incoming.updatedAt ? new Date(incoming.updatedAt).getTime() : Date.now();
+    if (currentUpdatedAt && incomingUpdatedAt < currentUpdatedAt) {
+      set({ loaded: true });
+      return;
+    }
+    set({ loaded: true, prefs: { backgroundVariant: incoming.backgroundVariant, aiPromptShinePreset: incoming.aiPromptShinePreset, updatedAt: incoming.updatedAt } });
+  },
+}));

--- a/packages/common/store/index.ts
+++ b/packages/common/store/index.ts
@@ -3,6 +3,7 @@ export * from './app.store';
 export * from './chat.store';
 export * from './mcp-tools.store';
 export * from './preferences.store';
+export * from './global-preferences.store';
 
 // Export types from shared
 export type { Thread, ThreadItem } from '@repo/shared/types';

--- a/packages/prisma/migrations/20250924020020_add_app_setting_ui_preferences/migration.sql
+++ b/packages/prisma/migrations/20250924020020_add_app_setting_ui_preferences/migration.sql
@@ -1,0 +1,8 @@
+-- CreateTable
+CREATE TABLE "AppSetting" (
+    "key" TEXT NOT NULL,
+    "value" JSONB NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT NOW(),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT NOW(),
+    CONSTRAINT "AppSetting_pkey" PRIMARY KEY ("key")
+);

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -92,3 +92,10 @@ model Feedback {
   metadata  Json?
   createdAt DateTime @default(now())
 }
+
+model AppSetting {
+  key       String  @id
+  value     Json
+  updatedAt DateTime @updatedAt
+  createdAt DateTime @default(now())
+}


### PR DESCRIPTION
## Force UI background + Shine globally (admin-controlled)

- Add AppSetting model + migration to persist ui.preferences { backgroundVariant, aiPromptShinePreset }
- Public GET /api/ui/preferences returns server-enforced prefs with updatedAt (defaults applied)
- Admin POST /api/admin/ui/preferences validates payload, upserts, logs Activity, and broadcasts
- Live updates via SSE /api/ui/stream using in-memory EventEmitter; clients fallback to polling
- Frontend: global preferences store + provider to fetch/init + stream updates; last-write-wins using updatedAt
- Enforce on chat and chat home only by wiring useEffectivePreferences in AnimatedChatInput + ChatInput
- Admin settings modal now posts to server and syncs stores; shows instant-apply hint

Why: Ensure a single source of truth for background and Shine presets, applied instantly to all users with conflict rule 'last change wins'.

Impact: Users see consistent styling on chat/home; admins control look globally; no personalization UI for non-admins.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/572a16e3-84af-11f0-a94e-3eef481a796b/task/660a4d53-4a77-4599-8758-24fece0aa39b))