### PR TITLE
Dark mode UI: set SearchLoadingState Card background to dark:bg-neutr…

### DIFF
--- a/packages/common/components/loader/search-loading-state.tsx
+++ b/packages/common/components/loader/search-loading-state.tsx
@@ -61,7 +61,9 @@ function Card({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="card"
       className={cn(
-        'bg-card text-card-foreground flex flex-col gap-6 rounded-3xl border py-6 shadow-sm relative overflow-hidden',
+        'flex flex-col gap-6 rounded-3xl border border-border py-6 shadow-sm relative overflow-hidden',
+        'bg-white text-foreground',
+        'dark:bg-neutral-900/80 dark:text-foreground',
         className
       )}
       {...props}


### PR DESCRIPTION
…al-900/80 (light: bg-white) with text-foreground and border-border for better contrast vs conversation background