### PR TITLE
Refonte UI/UX admin: dashboard layout + sidebar dédié; séparation sidebars

### DIFF
--- a/apps/web/app/admin/dashboard/layout.tsx
+++ b/apps/web/app/admin/dashboard/layout.tsx
@@ -1,0 +1,82 @@
+"use client";
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Button, cn } from '@repo/ui';
+import { AdminSidebar } from '@repo/common/components';
+import { ArrowUturnLeftIcon, Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
+
+export default function AdminDashboardLayout({ children }: { children: React.ReactNode }) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  useEffect(() => {
+    if (mobileOpen) document.body.classList.add('overflow-hidden');
+    else document.body.classList.remove('overflow-hidden');
+    return () => document.body.classList.remove('overflow-hidden');
+  }, [mobileOpen]);
+
+  return (
+    <div className="relative flex h-[100dvh] w-full">
+      <div className="hidden lg:flex">
+        <AdminSidebar variant="desktop" />
+      </div>
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header className="sticky top-0 z-30 flex items-center justify-between border-b bg-background/80 p-2 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+          <div className="flex items-center gap-2">
+            <button
+              className="lg:hidden inline-flex items-center justify-center rounded-md border p-2 text-sm hover:bg-accent"
+              onClick={() => setMobileOpen(true)}
+              aria-label="Ouvrir le menu"
+            >
+              <Bars3Icon className="size-5" />
+            </button>
+          </div>
+          <div className="flex-1" />
+          <Link href="/chat" aria-label="Retour au chat" title="Retour au chat">
+            <Button variant="secondary" className="inline-flex items-center gap-2">
+              <ArrowUturnLeftIcon className="size-4" />
+              <span>Retour au chat</span>
+            </Button>
+          </Link>
+        </header>
+
+        <main className="min-h-0 flex-1 overflow-y-auto p-4">{children}</main>
+      </div>
+
+      <AnimatePresence>
+        {mobileOpen && (
+          <>
+            <motion.div
+              key="overlay"
+              className="fixed inset-0 z-40 bg-black/40"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={() => setMobileOpen(false)}
+            />
+            <motion.div
+              key="panel"
+              className="fixed inset-y-0 left-0 z-50"
+              initial={{ x: -320 }}
+              animate={{ x: 0 }}
+              exit={{ x: -320 }}
+              transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+            >
+              <div className="relative h-full w-[300px] bg-background">
+                <button
+                  className="absolute right-2 top-2 inline-flex items-center justify-center rounded-md border p-2 text-sm hover:bg-accent"
+                  onClick={() => setMobileOpen(false)}
+                  aria-label="Fermer le menu"
+                >
+                  <XMarkIcon className="size-5" />
+                </button>
+                <AdminSidebar variant="mobile" onNavigate={() => setMobileOpen(false)} />
+              </div>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/apps/web/app/admin/dashboard/logs/page.tsx
+++ b/apps/web/app/admin/dashboard/logs/page.tsx
@@ -1,0 +1,108 @@
+'use client';
+import { useMemo, useState } from 'react';
+import { Button, Input } from '@repo/ui';
+
+interface LogRow {
+  ts: string;
+  type: 'info' | 'warn' | 'error';
+  message: string;
+}
+
+const TYPES: LogRow['type'][] = ['info', 'warn', 'error'];
+const MOCK_LOGS: LogRow[] = Array.from({ length: 113 }).map((_, i) => ({
+  ts: new Date(Date.now() - i * 60_000).toLocaleString('fr-FR'),
+  type: TYPES[i % TYPES.length],
+  message: `Événement #${i + 1} — tout est normal (mock)`,
+}));
+
+export default function LogsPage() {
+  const [query, setQuery] = useState('');
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(10);
+
+  const filtered = useMemo(() => {
+    const q = query.toLowerCase();
+    return MOCK_LOGS.filter(l => l.message.toLowerCase().includes(q) || l.type.includes(q));
+  }, [query]);
+
+  const totalPages = Math.ceil(filtered.length / perPage);
+  const data = useMemo(() => {
+    const start = (page - 1) * perPage;
+    return filtered.slice(start, start + perPage);
+  }, [page, perPage, filtered]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h1 className="text-xl font-semibold">Logs</h1>
+        <div className="flex items-center gap-2">
+          <Input
+            placeholder="Filtrer..."
+            value={query}
+            onChange={(e) => { setPage(1); setQuery(e.target.value); }}
+            className="w-[240px]"
+          />
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded-md border">
+        <table className="w-full table-auto text-sm">
+          <thead className="bg-muted/50">
+            <tr className="text-left">
+              <th className="px-3 py-2 font-medium">Horodatage</th>
+              <th className="px-3 py-2 font-medium">Type</th>
+              <th className="px-3 py-2 font-medium">Message</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((l, i) => (
+              <tr key={`${l.ts}-${i}`} className="border-t">
+                <td className="px-3 py-2 whitespace-nowrap">{l.ts}</td>
+                <td className="px-3 py-2 capitalize">{l.type}</td>
+                <td className="px-3 py-2">{l.message}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 text-sm">
+          <span>Lignes par page</span>
+          <select
+            className="rounded-md border bg-background px-2 py-1"
+            value={perPage}
+            onChange={(e) => { setPerPage(Number(e.target.value)); setPage(1); }}
+          >
+            {[10, 20, 50].map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button variant="secondary" disabled={page === 1} onClick={() => setPage((p) => Math.max(1, p - 1))}>
+            Précédent
+          </Button>
+          {Array.from({ length: totalPages }).map((_, i) => (
+            <Button
+              key={i}
+              variant={i + 1 === page ? 'default' : 'ghost'}
+              onClick={() => setPage(i + 1)}
+            >
+              {i + 1}
+            </Button>
+          ))}
+          <Button
+            variant="secondary"
+            disabled={page === totalPages}
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+          >
+            Suivant
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/dashboard/models/page.tsx
+++ b/apps/web/app/admin/dashboard/models/page.tsx
@@ -1,0 +1,102 @@
+'use client';
+import { useMemo, useState } from 'react';
+import { Button } from '@repo/ui';
+
+interface ModelRow {
+  name: string;
+  type: 'LLM' | 'Vision' | 'Speech';
+  version: string;
+  status: 'actif' | 'désactivé';
+}
+
+const MOCK_MODELS: ModelRow[] = [
+  { name: 'gpt-4o-mini', type: 'LLM', version: '4.0', status: 'actif' },
+  { name: 'gemini-1.5-pro', type: 'LLM', version: '1.5', status: 'actif' },
+  { name: 'whisper-large', type: 'Speech', version: '3', status: 'actif' },
+  { name: 'claude-3.5-sonnet', type: 'LLM', version: '3.5', status: 'désactivé' },
+  { name: 'llava-1.6', type: 'Vision', version: '1.6', status: 'actif' },
+];
+
+const ALL = Array.from({ length: 37 }).flatMap(() => MOCK_MODELS);
+
+export default function ModelsPage() {
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(10);
+
+  const totalPages = Math.ceil(ALL.length / perPage);
+  const data = useMemo(() => {
+    const start = (page - 1) * perPage;
+    return ALL.slice(start, start + perPage);
+  }, [page, perPage]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="text-xl font-semibold">Modèles</h1>
+
+      <div className="overflow-hidden rounded-md border">
+        <table className="w-full table-auto text-sm">
+          <thead className="bg-muted/50">
+            <tr className="text-left">
+              <th className="px-3 py-2 font-medium">Nom du modèle</th>
+              <th className="px-3 py-2 font-medium">Type</th>
+              <th className="px-3 py-2 font-medium">Version</th>
+              <th className="px-3 py-2 font-medium">Statut</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((m, i) => (
+              <tr key={`${m.name}-${i}`} className="border-t">
+                <td className="px-3 py-2">{m.name}</td>
+                <td className="px-3 py-2">{m.type}</td>
+                <td className="px-3 py-2">{m.version}</td>
+                <td className="px-3 py-2 capitalize">{m.status}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 text-sm">
+          <span>Lignes par page</span>
+          <select
+            className="rounded-md border bg-background px-2 py-1"
+            value={perPage}
+            onChange={(e) => {
+              setPerPage(Number(e.target.value));
+              setPage(1);
+            }}
+          >
+            {[10, 20, 50].map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex items-center gap-1">
+          <Button variant="secondary" disabled={page === 1} onClick={() => setPage((p) => Math.max(1, p - 1))}>
+            Précédent
+          </Button>
+          {Array.from({ length: totalPages }).map((_, i) => (
+            <Button
+              key={i}
+              variant={i + 1 === page ? 'default' : 'ghost'}
+              onClick={() => setPage(i + 1)}
+            >
+              {i + 1}
+            </Button>
+          ))}
+          <Button
+            variant="secondary"
+            disabled={page === totalPages}
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+          >
+            Suivant
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/dashboard/settings/page.tsx
+++ b/apps/web/app/admin/dashboard/settings/page.tsx
@@ -1,0 +1,69 @@
+'use client';
+import { useState } from 'react';
+import { Button, Input, Switch } from '@repo/ui';
+
+export default function SettingsPage() {
+  const [features, setFeatures] = useState({
+    allowSignup: true,
+    enableLogs: true,
+    maintenanceMode: false,
+  });
+  const [modelDefault, setModelDefault] = useState('gpt-4o-mini');
+
+  return (
+    <div className="flex flex-col gap-6">
+      <h1 className="text-xl font-semibold">Paramètres</h1>
+
+      <section className="rounded-md border p-4">
+        <h2 className="mb-3 text-base font-medium">Général</h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="flex items-center justify-between gap-4 rounded-md border p-3">
+            <div className="flex flex-col">
+              <span className="text-sm font-medium">Inscription ouverte</span>
+              <span className="text-xs text-muted-foreground">Permet aux nouveaux utilisateurs de créer un compte</span>
+            </div>
+            <Switch checked={features.allowSignup} onCheckedChange={(v) => setFeatures(f => ({ ...f, allowSignup: v }))} />
+          </div>
+
+          <div className="flex items-center justify-between gap-4 rounded-md border p-3">
+            <div className="flex flex-col">
+              <span className="text-sm font-medium">Journalisation</span>
+              <span className="text-xs text-muted-foreground">Active les logs d'activité</span>
+            </div>
+            <Switch checked={features.enableLogs} onCheckedChange={(v) => setFeatures(f => ({ ...f, enableLogs: v }))} />
+          </div>
+
+          <div className="flex items-center justify-between gap-4 rounded-md border p-3">
+            <div className="flex flex-col">
+              <span className="text-sm font-medium">Mode maintenance</span>
+              <span className="text-xs text-muted-foreground">Affiche une page de maintenance</span>
+            </div>
+            <Switch checked={features.maintenanceMode} onCheckedChange={(v) => setFeatures(f => ({ ...f, maintenanceMode: v }))} />
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-md border p-4">
+        <h2 className="mb-3 text-base font-medium">Modèles</h2>
+        <div className="flex flex-col gap-2 sm:max-w-md">
+          <label className="text-sm font-medium">Modèle par défaut</label>
+          <select
+            className="rounded-md border bg-background px-2 py-1"
+            value={modelDefault}
+            onChange={(e) => setModelDefault(e.target.value)}
+          >
+            <option value="gpt-4o-mini">gpt-4o-mini</option>
+            <option value="gemini-1.5-pro">gemini-1.5-pro</option>
+            <option value="claude-3.5-sonnet">claude-3.5-sonnet</option>
+          </select>
+          <p className="text-xs text-muted-foreground">Ces réglages sont des placeholders et ne sont pas persistés.</p>
+        </div>
+      </section>
+
+      <div className="flex items-center gap-2">
+        <Button disabled>Enregistrer (placeholder)</Button>
+        <Button variant="secondary">Réinitialiser</Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/dashboard/users/page.tsx
+++ b/apps/web/app/admin/dashboard/users/page.tsx
@@ -1,0 +1,103 @@
+'use client';
+import { useMemo, useState } from 'react';
+import { Button, Input } from '@repo/ui';
+
+interface UserRow {
+  id: string;
+  email: string;
+  role: 'user' | 'admin';
+  status: 'actif' | 'désactivé';
+  createdAt: string;
+}
+
+const MOCK_USERS: UserRow[] = Array.from({ length: 57 }).map((_, i) => ({
+  id: String(1000 + i),
+  email: `user${i + 1}@exemple.com`,
+  role: i % 10 === 0 ? 'admin' : 'user',
+  status: i % 7 === 0 ? 'désactivé' : 'actif',
+  createdAt: new Date(Date.now() - i * 86400000).toLocaleDateString('fr-FR'),
+}));
+
+export default function UsersPage() {
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(10);
+
+  const totalPages = Math.ceil(MOCK_USERS.length / perPage);
+  const data = useMemo(() => {
+    const start = (page - 1) * perPage;
+    return MOCK_USERS.slice(start, start + perPage);
+  }, [page, perPage]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="text-xl font-semibold">Utilisateurs</h1>
+
+      <div className="overflow-hidden rounded-md border">
+        <table className="w-full table-auto text-sm">
+          <thead className="bg-muted/50">
+            <tr className="text-left">
+              <th className="px-3 py-2 font-medium">ID</th>
+              <th className="px-3 py-2 font-medium">Email</th>
+              <th className="px-3 py-2 font-medium">Rôle</th>
+              <th className="px-3 py-2 font-medium">Statut</th>
+              <th className="px-3 py-2 font-medium">Créé le</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((u) => (
+              <tr key={u.id} className="border-t">
+                <td className="px-3 py-2">{u.id}</td>
+                <td className="px-3 py-2">{u.email}</td>
+                <td className="px-3 py-2 capitalize">{u.role}</td>
+                <td className="px-3 py-2 capitalize">{u.status}</td>
+                <td className="px-3 py-2">{u.createdAt}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 text-sm">
+          <span>Lignes par page</span>
+          <select
+            className="rounded-md border bg-background px-2 py-1"
+            value={perPage}
+            onChange={(e) => {
+              setPerPage(Number(e.target.value));
+              setPage(1);
+            }}
+          >
+            {[10, 20, 50].map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex items-center gap-1">
+          <Button variant="secondary" disabled={page === 1} onClick={() => setPage((p) => Math.max(1, p - 1))}>
+            Précédent
+          </Button>
+          {Array.from({ length: totalPages }).map((_, i) => (
+            <Button
+              key={i}
+              variant={i + 1 === page ? 'default' : 'ghost'}
+              onClick={() => setPage(i + 1)}
+            >
+              {i + 1}
+            </Button>
+          ))}
+          <Button
+            variant="secondary"
+            disabled={page === totalPages}
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+          >
+            Suivant
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -73,6 +73,7 @@
         "fast-xml-parser": "^4.5.1",
         "formik": "^2.4.6",
         "framer-motion": "^11.1.9",
+        "@heroicons/react": "^2.1.5",
         "geist": "^1.3.1",
         "highlight.js": "^11.9.0",
         "html-entities": "^2.6.0",

--- a/packages/common/components/admin/AdminSidebar.tsx
+++ b/packages/common/components/admin/AdminSidebar.tsx
@@ -1,0 +1,101 @@
+"use client";
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { motion, AnimatePresence } from 'framer-motion';
+import { cn, Button } from '@repo/ui';
+import { useAdminUIStore } from '@repo/common/store';
+import {
+  UserGroupIcon,
+  RectangleStackIcon,
+  DocumentTextIcon,
+  Cog6ToothIcon,
+  ChevronDoubleLeftIcon,
+} from '@heroicons/react/24/outline';
+import { useMemo, useState } from 'react';
+
+const NAV_ITEMS = [
+  { href: '/admin/dashboard/users', label: 'Utilisateurs', Icon: UserGroupIcon },
+  { href: '/admin/dashboard/models', label: 'Modèles', Icon: RectangleStackIcon },
+  { href: '/admin/dashboard/logs', label: 'Logs', Icon: DocumentTextIcon },
+  { href: '/admin/dashboard/settings', label: 'Paramètres', Icon: Cog6ToothIcon },
+] as const;
+
+type AdminSidebarProps = {
+  variant?: 'desktop' | 'mobile';
+  onNavigate?: () => void;
+};
+
+export function AdminSidebar({ variant = 'desktop', onNavigate }: AdminSidebarProps) {
+  const pathname = usePathname();
+  const isMobile = variant === 'mobile';
+  const isAdminSidebarOpen = useAdminUIStore(s => s.isAdminSidebarOpen);
+  const setIsAdminSidebarOpen = useAdminUIStore(s => s.setIsAdminSidebarOpen);
+  const [hovered, setHovered] = useState(false);
+
+  const expanded = isMobile ? true : isAdminSidebarOpen || hovered;
+  const width = expanded ? 300 : 60;
+
+  const items = useMemo(() => NAV_ITEMS, []);
+
+  return (
+    <motion.aside
+      initial={false}
+      animate={{ width }}
+      transition={{ type: 'spring', stiffness: 260, damping: 30 }}
+      className={cn(
+        'relative z-40 flex h-[100dvh] flex-col border-r bg-background',
+        isMobile ? 'w-[300px]' : 'hidden lg:flex'
+      )}
+      onMouseEnter={() => !isMobile && setHovered(true)}
+      onMouseLeave={() => !isMobile && setHovered(false)}
+      role="navigation"
+      aria-label="Navigation admin"
+    >
+      <div className="flex flex-col gap-2 p-2">
+        <div className={cn('flex items-center justify-between', expanded ? 'px-1' : 'px-0')}></div>
+        <nav>
+          <ul role="list" className="flex flex-col gap-1">
+            {items.map(({ href, label, Icon }) => {
+              const active = pathname.startsWith(href);
+              return (
+                <li key={href} role="listitem">
+                  <Link
+                    href={href}
+                    onClick={() => onNavigate?.()}
+                    className={cn(
+                      'group flex w-full items-center gap-3 rounded-md px-2 py-2 text-sm outline-none transition-colors',
+                      active
+                        ? 'bg-accent/60 text-foreground'
+                        : 'text-muted-foreground hover:bg-accent/40 hover:text-foreground'
+                    )}
+                    aria-current={active ? 'page' : undefined}
+                  >
+                    <Icon className={cn('size-5 shrink-0', active && 'text-foreground')} />
+                    {expanded && <span className="truncate">{label}</span>}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+      </div>
+
+      {!isMobile && (
+        <div className="mt-auto p-2">
+          <Button
+            variant="ghost"
+            size={expanded ? 'sm' : 'icon'}
+            className={cn('w-full justify-center')}
+            onClick={() => setIsAdminSidebarOpen(prev => !prev)}
+            aria-label={expanded ? 'Réduire le menu' : 'Étendre le menu'}
+            tooltip={expanded ? 'Réduire' : 'Étendre'}
+            tooltipSide="right"
+          >
+            <ChevronDoubleLeftIcon className={cn('size-5 transition-transform', !expanded && 'rotate-180')} />
+            {expanded && <span className="ml-2">Réduire</span>}
+          </Button>
+        </div>
+      )}
+    </motion.aside>
+  );
+}

--- a/packages/common/components/index.ts
+++ b/packages/common/components/index.ts
@@ -33,3 +33,4 @@ export * from './thread';
 export * from './tools-menu';
 export * from './loader/search-loading-state';
 export * from './loader/model-icons';
+export * from './admin/AdminSidebar';

--- a/packages/common/components/layout/root.tsx
+++ b/packages/common/components/layout/root.tsx
@@ -53,24 +53,26 @@ export const RootLayout: FC<TRootLayout> = ({ children }) => {
                 </div>
             </div>
             <Flex className="hidden lg:flex">
-                <AnimatePresence>{isSidebarOpen && <Sidebar />}</AnimatePresence>
+                <AnimatePresence>{isChat && isSidebarOpen && <Sidebar />}</AnimatePresence>
             </Flex>
 
-            <Drawer.Root
-                open={isMobileSidebarOpen}
-                direction="left"
-                shouldScaleBackground
-                onOpenChange={setIsMobileSidebarOpen}
-            >
-                <Drawer.Portal>
-                    <Drawer.Overlay className="fixed inset-0 z-30 backdrop-blur-sm" />
-                    <Drawer.Content className="fixed bottom-0 left-0 top-0 z-[50]">
-                        <Flex className="pr-2">
-                            <Sidebar />
-                        </Flex>
-                    </Drawer.Content>
-                </Drawer.Portal>
-            </Drawer.Root>
+            {isChat && (
+                <Drawer.Root
+                    open={isMobileSidebarOpen}
+                    direction="left"
+                    shouldScaleBackground
+                    onOpenChange={setIsMobileSidebarOpen}
+                >
+                    <Drawer.Portal>
+                        <Drawer.Overlay className="fixed inset-0 z-30 backdrop-blur-sm" />
+                        <Drawer.Content className="fixed bottom-0 left-0 top-0 z-[50]">
+                            <Flex className="pr-2">
+                                <Sidebar />
+                            </Flex>
+                        </Drawer.Content>
+                    </Drawer.Portal>
+                </Drawer.Root>
+            )}
 
             {/* Main Content */}
             <Flex className="flex-1 overflow-hidden">

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -22,6 +22,7 @@
     "@tiptap/extension-character-count": "^2.11.7",
     "react-intl": "^6.6.3",
     "xlsx": "^0.18.5",
+    "@heroicons/react": "^2.1.5",
     "motion": "^11.18.0"
   },
   "devDependencies": {

--- a/packages/common/store/admin-ui.store.ts
+++ b/packages/common/store/admin-ui.store.ts
@@ -1,0 +1,38 @@
+"use client";
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+
+type State = {
+  isAdminSidebarOpen: boolean;
+};
+
+type Actions = {
+  setIsAdminSidebarOpen: (updater: (prev: boolean) => boolean) => void;
+};
+
+const PERSIST_KEY = 'admin.dashboard.sidebar.open';
+
+export const useAdminUIStore = create(
+  immer<State & Actions>((set, get) => ({
+    isAdminSidebarOpen:
+      typeof window !== 'undefined'
+        ? (() => {
+            try {
+              const v = window.localStorage.getItem(PERSIST_KEY);
+              return v ? JSON.parse(v) : true;
+            } catch {
+              return true;
+            }
+          })()
+        : true,
+    setIsAdminSidebarOpen: (updater: (prev: boolean) => boolean) =>
+      set(state => {
+        const next = updater(state.isAdminSidebarOpen);
+        try {
+          if (typeof window !== 'undefined')
+            window.localStorage.setItem(PERSIST_KEY, JSON.stringify(next));
+        } catch {}
+        return { isAdminSidebarOpen: next };
+      }),
+  }))
+);

--- a/packages/common/store/index.ts
+++ b/packages/common/store/index.ts
@@ -5,6 +5,7 @@ export * from './mcp-tools.store';
 export * from './preferences.store';
 export * from './global-preferences.store';
 export * from './allowed-chat-modes.store';
+export * from './admin-ui.store';
 
 // Export types from shared
 export type { Thread, ThreadItem } from '@repo/shared/types';


### PR DESCRIPTION
Contexte\n- Next.js App Router avec /chat et /admin (garde serveur role==='admin').\n- Le sidebar de chat était monté globalement, empêchant un sidebar dédié admin.\n\nCe que cette PR apporte\n1) Séparation des sidebars par sections\n- Chat: le sidebar historique ne s'affiche que sur /chat/* (desktop + drawer mobile).\n- Admin dashboard: nouveau AdminSidebar affiché uniquement sous /admin/dashboard/*.\n\n2) Nouveau layout pour /admin/dashboard\n- apps/web/app/admin/dashboard/layout.tsx: header sticky avec bouton "Retour au chat" (ArrowUturnLeft) -> /chat.\n- Responsive: desktop (300px ouvert / 60px réduit, hover pour étendre), mobile (burger -> slide-in full-height via framer-motion, overlay cliquable, lock du scroll).\n\n3) AdminSidebar dédié\n- packages/common/components/admin/AdminSidebar.tsx: framer-motion, état via Zustand (useAdminUIStore avec persistance).\n- Icônes Heroicons outline: Utilisateurs (UserGroupIcon), Modèles (RectangleStackIcon), Logs (DocumentTextIcon), Paramètres (Cog6ToothIcon).\n- Largeurs: 300px (ouvert) / 60px (réduit), collapse on hover, aria-current pour l'item actif, roles/navigation/listitem.\n\n4) Pages internes du dashboard (placeholders)\n- /admin/dashboard/users: table (ID, Email, Rôle, Statut, Créé le) + pagination 10/20/50.\n- /admin/dashboard/models: table (Nom du modèle, Type, Version, Statut) + pagination.\n- /admin/dashboard/logs: table (Horodatage, Type, Message) + filtrage texte + pagination.\n- /admin/dashboard/settings: formulaire placeholder (toggles/select), non persisté.\n\n5) Intégration et conditionnement par route\n- packages/common/components/layout/root.tsx: rendu du chat Sidebar et du Drawer mobile conditionnés à pathname.startsWith('/chat').\n- AdminSidebar uniquement rendu dans /admin/dashboard/layout.tsx.\n\nSécurité / garde d'accès\n- /admin et /admin/dashboard héritent de apps/web/app/admin/layout.tsx (role==='admin').\n\nAccessibilité\n- aria-current sur item actif, roles navigation/listitem, focus rings conservés via composants UI.\n\nDétails techniques\n- Nouveau store: packages/common/store/admin-ui.store.ts (Zustand + persistance localStorage).\n- Exports mis à jour: packages/common/components/index.ts et packages/common/store/index.ts.\n- Dépendances: ajout @heroicons/react.\n\nFichiers principaux\n- apps/web/app/admin/dashboard/layout.tsx\n- apps/web/app/admin/dashboard/{users,models,logs,settings}/page.tsx\n- packages/common/components/admin/AdminSidebar.tsx\n- packages/common/components/layout/root.tsx (conditionnement du chat Sidebar)\n- packages/common/store/admin-ui.store.ts\n\nTests manuels rapides\n- Desktop/mobile: navigation entre /chat et /admin/dashboard/*, ouverture/fermeture sidebar, overlay mobile cliquable, focus clavier.\n- Vérifier que le sidebar chat n'apparaît pas sous /admin/* et qu'il reste intact sous /chat/*.\n\nChecklist d'acceptation\n- [x] Sidebar historique visible uniquement sous /chat/*\n- [x] /admin inchangé et garde serveur conservée\n- [x] /admin/dashboard: header + AdminSidebar + zone de contenu\n- [x] Pages: users/models/logs/settings (placeholders)\n- [x] Icônes Heroicons et état actif clair\n- [x] Aucune régression sur /chat\n\nNotes\n- Après merge, exécuter une installation pour @heroicons/react si le CI ne gère pas automatiquement (ex: bun install).