### PR TITLE
Limit single-device login to role 'user' (exclude admins)

### DIFF
--- a/apps/web/app/api/_lib/auth.ts
+++ b/apps/web/app/api/_lib/auth.ts
@@ -61,7 +61,10 @@ export async function createSessionForUser(userId: string, request: NextRequest)
   const gl = geolocation(request);
   const ip = getIp(request);
 
-  await prisma.session.deleteMany({ where: { userId } });
+  const user = await prisma.user.findUnique({ where: { id: userId }, select: { role: true } });
+  if (user?.role === 'user') {
+    await prisma.session.deleteMany({ where: { userId } });
+  }
 
   await prisma.session.create({
     data: {


### PR DESCRIPTION
# Limiter la connexion « un seul appareil » au rôle `user`

## Contexte
Actuellement, lors d’une connexion, l’application supprime toutes les sessions existantes de l’utilisateur, ce qui force la déconnexion des autres appareils. Cette règle s’appliquait à tous les comptes, y compris les administrateurs.

## Changement
La règle « un seul appareil à la fois » ne s’applique plus qu’aux utilisateurs avec le rôle `user`. Les comptes `admin` peuvent désormais conserver plusieurs sessions actives simultanément (pas de révocation automatique lors d’une nouvelle connexion).

## Détails techniques
- Fichier: `apps/web/app/api/_lib/auth.ts`
- Fonction: `createSessionForUser`
- Modification: récupération du rôle de l’utilisateur via Prisma (`user.role`) et suppression conditionnelle des sessions précédentes uniquement si `role === 'user'`.

```ts
const user = await prisma.user.findUnique({ where: { id: userId }, select: { role: true } });
if (user?.role === 'user') {
  await prisma.session.deleteMany({ where: { userId } });
}
```

Aucun autre flux n’est modifié (révocations explicites lors de reset mot de passe / suppression de compte, etc., restent inchangées).

## Impact
- Utilisateurs (`user`): toujours limités à une seule session; une nouvelle connexion invalide la précédente.
- Administrateurs (`admin`): peuvent se connecter sur plusieurs appareils sans invalider les sessions existantes.

## Validation
- Build/typage passe localement (modification TypeScript minimale et sûre).
- Comportement centré sur un point d’entrée unique: `createSessionForUser` (appelée au login).

## Compatibilité
Aucun script de migration requis. Le modèle de données reste inchangé.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/572ab1e1-84af-11f0-a94e-3eef481a796b/task/87fce225-8752-4502-ac8d-b04f617dce08))