### PR TITLE
Unify SearchLoadingState visual rule via per-model theme

### DIFF
--- a/packages/common/components/loader/model-icons.tsx
+++ b/packages/common/components/loader/model-icons.tsx
@@ -8,18 +8,18 @@ import { IconAtom, IconNorthStar, IconTable, IconFile, IconFileSpreadsheet } fro
 export function getModelIconByChatMode(mode: ChatMode): React.ReactNode {
   switch (mode) {
     case ChatMode.CORRECTION:
-      return <IconPencil size={16} strokeWidth={2} className="text-white" />;
+      return <IconPencil size={16} strokeWidth={2} className="text-emerald-600 dark:text-emerald-400" />;
     case ChatMode.CLASSIFICATION:
-      return <IconTable size={16} strokeWidth={2} className="text-white" />;
+      return <IconTable size={16} strokeWidth={2} className="text-indigo-600 dark:text-indigo-400" />;
     case ChatMode.NOMENCLATURE_DOUANIERE:
-      return <IconFile size={16} strokeWidth={2} className="text-white" />;
+      return <IconFile size={16} strokeWidth={2} className="text-amber-600 dark:text-amber-400" />;
     case ChatMode.SMART_PDF_TO_EXCEL:
-      return <IconFileSpreadsheet size={16} strokeWidth={2} className="text-white" />;
+      return <IconFileSpreadsheet size={16} strokeWidth={2} className="text-emerald-600 dark:text-emerald-400" />;
 
     case ChatMode.Deep:
-      return <IconAtom size={16} strokeWidth={2} className="text-white" />;
+      return <IconAtom size={16} strokeWidth={2} className="text-fuchsia-600 dark:text-fuchsia-400" />;
     case ChatMode.Pro:
-      return <IconNorthStar size={16} strokeWidth={2} className="text-white" />;
+      return <IconNorthStar size={16} strokeWidth={2} className="text-blue-600 dark:text-blue-400" />;
 
     case ChatMode.GEMINI_2_5_FLASH:
     case ChatMode.GEMINI_2_5_PRO:
@@ -43,7 +43,7 @@ export function getModelIconByChatMode(mode: ChatMode): React.ReactNode {
       return ModelIcons.DEEPSEEK;
 
     default:
-      return <Bot className="w-4 h-4" />;
+      return <Bot className="w-4 h-4 text-neutral-600 dark:text-neutral-400" />;
   }
 }
 
@@ -53,50 +53,79 @@ export function getModelThemeByChatMode(mode: ChatMode): { icon: React.ReactNode
       return {
         icon: getModelIconByChatMode(mode),
         gradientClass: 'from-emerald-500 via-teal-500 to-cyan-500',
-        iconBgClass: 'bg-emerald-600 dark:bg-emerald-500',
+        iconBgClass: 'bg-emerald-50 dark:bg-emerald-950',
       };
     case ChatMode.CLASSIFICATION:
       return {
         icon: getModelIconByChatMode(mode),
         gradientClass: 'from-indigo-500 via-violet-500 to-sky-500',
-        iconBgClass: 'bg-indigo-600 dark:bg-indigo-500',
+        iconBgClass: 'bg-indigo-50 dark:bg-indigo-950',
       };
     case ChatMode.NOMENCLATURE_DOUANIERE:
       return {
         icon: getModelIconByChatMode(mode),
         gradientClass: 'from-amber-500 via-yellow-500 to-lime-500',
-        iconBgClass: 'bg-amber-600 dark:bg-amber-500',
+        iconBgClass: 'bg-amber-50 dark:bg-amber-950',
       };
     case ChatMode.SMART_PDF_TO_EXCEL:
       return {
         icon: getModelIconByChatMode(mode),
         gradientClass: 'from-green-600 via-emerald-500 to-lime-400',
-        iconBgClass: 'bg-emerald-600 dark:bg-emerald-500',
+        iconBgClass: 'bg-emerald-50 dark:bg-emerald-950',
       };
     case ChatMode.GEMINI_2_5_FLASH:
     case ChatMode.GEMINI_2_5_PRO:
       return {
         icon: getModelIconByChatMode(mode),
         gradientClass: 'from-sky-500 via-blue-500 to-indigo-500',
-        iconBgClass: 'bg-sky-600 dark:bg-sky-500',
+        iconBgClass: 'bg-sky-50 dark:bg-sky-950',
+      };
+    case ChatMode.GPT_4_1:
+    case ChatMode.GPT_4_1_Mini:
+    case ChatMode.GPT_4_1_Nano:
+    case ChatMode.GPT_4o_Mini:
+    case ChatMode.O4_Mini:
+      return {
+        icon: getModelIconByChatMode(mode),
+        gradientClass: 'from-neutral-400 via-neutral-500 to-neutral-600',
+        iconBgClass: 'bg-neutral-50 dark:bg-neutral-950',
+      };
+    case ChatMode.CLAUDE_3_5_SONNET:
+    case ChatMode.CLAUDE_3_7_SONNET:
+      return {
+        icon: getModelIconByChatMode(mode),
+        gradientClass: 'from-neutral-400 via-neutral-500 to-neutral-600',
+        iconBgClass: 'bg-neutral-50 dark:bg-neutral-950',
+      };
+    case ChatMode.LLAMA_4_SCOUT:
+      return {
+        icon: getModelIconByChatMode(mode),
+        gradientClass: 'from-neutral-400 via-neutral-500 to-neutral-600',
+        iconBgClass: 'bg-purple-50 dark:bg-purple-950',
+      };
+    case ChatMode.DEEPSEEK_R1:
+      return {
+        icon: getModelIconByChatMode(mode),
+        gradientClass: 'from-neutral-400 via-neutral-500 to-neutral-600',
+        iconBgClass: 'bg-rose-50 dark:bg-rose-950',
       };
     case ChatMode.Deep:
       return {
         icon: getModelIconByChatMode(mode),
         gradientClass: 'from-fuchsia-500 via-violet-500 to-rose-500',
-        iconBgClass: 'bg-fuchsia-600 dark:bg-fuchsia-500',
+        iconBgClass: 'bg-fuchsia-50 dark:bg-fuchsia-950',
       };
     case ChatMode.Pro:
       return {
         icon: getModelIconByChatMode(mode),
         gradientClass: 'from-cyan-500 via-blue-600 to-indigo-600',
-        iconBgClass: 'bg-blue-600 dark:bg-blue-500',
+        iconBgClass: 'bg-blue-50 dark:bg-blue-950',
       };
     default:
       return {
         icon: getModelIconByChatMode(mode),
         gradientClass: 'from-neutral-400 via-neutral-500 to-neutral-600',
-        iconBgClass: 'bg-neutral-700 dark:bg-neutral-600',
+        iconBgClass: 'bg-neutral-50 dark:bg-neutral-950',
       };
   }
 }


### PR DESCRIPTION
Title: Unify SearchLoadingState visual rule via per-model theme

Summary
- Why: Ensure a consistent visual language across all models during loading, improving recognition and coherence without touching the global SearchLoadingState component.
- What: Icons now use each model’s primary color; the circular background uses a light variant in light mode and a dark variant in dark mode; gradients and animations unchanged.
- How: Implemented entirely via model theme helpers (getModelIconByChatMode, getModelThemeByChatMode), preserving existing usages.

Changes
- getModelIconByChatMode
  - Replaced generic text-white with per-mode classes:
    - CORRECTION → text-emerald-600 dark:text-emerald-400
    - CLASSIFICATION → text-indigo-600 dark:text-indigo-400
    - NOMENCLATURE_DOUANIERE → text-amber-600 dark:text-amber-400
    - SMART_PDF_TO_EXCEL → text-emerald-600 dark:text-emerald-400
    - Deep → text-fuchsia-600 dark:text-fuchsia-400
    - Pro → text-blue-600 dark:text-blue-400
    - GEMINI, OPENAI, ANTHROPIC, META, DEEPSEEK → keep brand icons unchanged
    - Fallback → text-neutral-600 dark:text-neutral-400
- getModelThemeByChatMode
  - Set iconBgClass to light/dark variants per mode:
    - CORRECTION → bg-emerald-50 dark:bg-emerald-950
    - CLASSIFICATION → bg-indigo-50 dark:bg-indigo-950
    - NOMENCLATURE_DOUANIERE → bg-amber-50 dark:bg-amber-950
    - SMART_PDF_TO_EXCEL → bg-emerald-50 dark:bg-emerald-950
    - Deep → bg-fuchsia-50 dark:bg-fuchsia-950
    - Pro → bg-blue-50 dark:bg-blue-950
    - GEMINI → bg-sky-50 dark:bg-sky-950
    - OPENAI (GPT 4.x, O4 Mini) → bg-neutral-50 dark:bg-neutral-950
    - ANTHROPIC (Claude) → bg-neutral-50 dark:bg-neutral-950
    - META (Llama) → bg-purple-50 dark:bg-purple-950
    - DEEPSEEK → bg-rose-50 dark:bg-rose-950
    - Default → bg-neutral-50 dark:bg-neutral-950
  - Kept gradientClass values exactly as before.

Verification
- No changes to SearchLoadingState; wrapper still sets text-white, but icon components now explicitly set their color to override inheritance.
- Usages in GeneratingStatus, ThreadItem (no response fallback), and StepRenderer (pending banner) pass iconBgClass and gradientClass as before.
- No side effects on other components.

Impact
- Consistent, brand-aware loading visuals across all models.
- Dark/light modes supported with appropriate contrast.

Notes
- Brand logos that are not currentColor-based remain un-tinted by design; only the circular background follows the rule.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/572ab1e1-84af-11f0-a94e-3eef481a796b/task/962fbf2a-5bd4-420e-9b59-96ce0d62f308))