### PR TITLE
Fix missing BentoGrid import in admin metrics header

### DIFF
--- a/apps/web/app/admin/_components/metrics.tsx
+++ b/apps/web/app/admin/_components/metrics.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useMemo, useState } from 'react';
-import { BentoCard } from './bento-card';
+import { BentoCard, BentoGrid } from './bento-card';
 
 export type WindowSel = '24h' | '7j' | '30j';
 


### PR DESCRIPTION
## Summary
- restore the BentoGrid import in the admin metrics header so TypeScript can resolve the component

## Testing
- not run (not requested)


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/679f78dc-80e1-4c7b-8f79-c86971b9f778/task/b17e50dc-f5b4-4f7e-84be-772931ccf29a))