### PR TITLE
Reduce streaming TTFB <1s: end-to-end instrumentation, SSE init, first-token flush, Edge toggle, telemetry, and search tuning

### DIFF
--- a/apps/web/app/api/completion/route.ts
+++ b/apps/web/app/api/completion/route.ts
@@ -11,13 +11,16 @@ import {
 import { executeStream, sendMessage } from './stream-handlers';
 import { completionRequestSchema, SSE_HEADERS } from './types';
 import { getIp } from './utils';
-import { prisma } from '@repo/prisma';
 import { getModelFromChatMode, models, estimateTokensForMessages } from '@repo/ai/models';
+
+export const runtime = process.env.EDGE_RUNTIME === 'true' ? 'edge' : 'nodejs';
 
 export async function POST(request: NextRequest) {
     if (request.method === 'OPTIONS') {
         return new Response(null, { headers: SSE_HEADERS });
     }
+
+    const t0 = Date.now();
 
     try {
         const session = await getSession(request);
@@ -47,14 +50,10 @@ export async function POST(request: NextRequest) {
             });
         }
 
-        console.log('ip', ip);
-
         const remainingCredits = await getRemainingCredits({
             userId: userId ?? undefined,
             ip,
         });
-
-        console.log('remainingCredits', remainingCredits, creditCost, process.env.NODE_ENV);
 
         if (!!ChatModeConfig[data.mode]?.isAuthRequired && !userId) {
             return new Response(JSON.stringify({ error: 'Authentification requise' }), {
@@ -88,7 +87,23 @@ export async function POST(request: NextRequest) {
 
         const gl = geolocation(request);
 
-        console.log('gl', gl);
+        // Compute provider/model and correlation id early for init event
+        let provider = 'openai';
+        let modelId = 'gpt-4o-mini';
+        try {
+            const mEnum = getModelFromChatMode(data.mode);
+            const mObj = models.find(m => m.id === mEnum);
+            if (mObj) {
+                provider = mObj.provider as string;
+                modelId = mObj.id as unknown as string;
+            }
+        } catch {}
+
+        const correlationId = (globalThis.crypto?.randomUUID
+            ? globalThis.crypto.randomUUID()
+            : `${Date.now()}-${Math.random().toString(36).slice(2)}`) as string;
+
+        const t1 = Date.now();
 
         const stream = createCompletionStream({
             data,
@@ -96,6 +111,11 @@ export async function POST(request: NextRequest) {
             ip,
             abortController,
             gl,
+            provider,
+            modelId,
+            t0,
+            t1,
+            correlationId,
         });
 
         return new Response(stream, { headers: enhancedHeaders });
@@ -114,12 +134,22 @@ function createCompletionStream({
     ip,
     abortController,
     gl,
+    provider,
+    modelId,
+    t0,
+    t1,
+    correlationId,
 }: {
     data: any;
     userId?: string;
     ip?: string;
     abortController: AbortController;
     gl: Geo;
+    provider: string;
+    modelId: string;
+    t0: number;
+    t1: number;
+    correlationId: string;
 }) {
     const encoder = new TextEncoder();
 
@@ -127,6 +157,9 @@ function createCompletionStream({
     return new ReadableStream({
         async start(controller) {
             let heartbeatInterval: NodeJS.Timeout | null = null;
+
+            // Send initial comment to flush headers immediately
+            controller.enqueue(encoder.encode(': keep-alive\n\n'));
 
             heartbeatInterval = setInterval(() => {
                 controller.enqueue(encoder.encode(': heartbeat\n\n'));
@@ -136,30 +169,82 @@ function createCompletionStream({
             const creditCost = CHAT_MODE_CREDIT_COSTS[
                 data.mode as keyof typeof CHAT_MODE_CREDIT_COSTS
             ];
-            let provider = 'openai';
-            let modelId = 'gpt-4o-mini';
-            try {
-                const mEnum = getModelFromChatMode(data.mode);
-                const mObj = models.find(m => m.id === mEnum);
-                if (mObj) {
-                    provider = mObj.provider as string;
-                    modelId = mObj.id as unknown as string;
-                }
-            } catch {}
 
-            const logMessage = async (status: 'COMPLETED' | 'ERROR' | 'ABORTED', errorCode?: string) => {
+            // Send SSE init event with correlation and basic info
+            const initPayload = {
+                type: 'init',
+                correlationId,
+                server: {
+                    t0,
+                    t1,
+                },
+                mode: data.mode,
+                model: modelId,
+                provider,
+                region: { country: gl?.country, region: gl?.region, city: gl?.city },
+                threadId: data.threadId,
+                threadItemId: data.threadItemId,
+                parentThreadItemId: data.parentThreadItemId,
+            };
+            try {
+                const message = `event: init\ndata: ${JSON.stringify(initPayload)}\n\n`;
+                controller.enqueue(encoder.encode(message));
+            } catch (e) {
+                // ignore
+            }
+            const t4 = Date.now();
+
+            // Persist initial TTFB server timings if possible (node only)
+            (async () => {
+                try {
+                    const { prisma } = await import('@repo/prisma');
+                    await prisma.telemetryTTFB.upsert({
+                        where: { correlationId },
+                        create: {
+                            correlationId,
+                            userId: userId ?? null,
+                            mode: data.mode,
+                            provider,
+                            model: modelId,
+                            region: gl?.region || null,
+                            t0: new Date(t0),
+                            t1: new Date(t1),
+                            t4: new Date(t4),
+                            preProcessingMs: t1 - t0,
+                            serverTTFBMs: t4 - t0,
+                        },
+                        update: {
+                            t0: new Date(t0),
+                            t1: new Date(t1),
+                            t4: new Date(t4),
+                            preProcessingMs: t1 - t0,
+                            serverTTFBMs: t4 - t0,
+                        },
+                    });
+                } catch (e) {
+                    console.warn('Telemetry persistence unavailable (likely Edge runtime):', e);
+                }
+            })();
+
+            const logMessage = async (
+                status: 'COMPLETED' | 'ERROR' | 'ABORTED',
+                errorCode?: string
+            ) => {
                 const latencyMs = Date.now() - startTs;
                 const costUsdCents = status === 'COMPLETED' ? creditCost * 5 : 0;
                 let promptTokens: number | null = null;
                 try {
                     if (usageRef?.promptTokens != null) promptTokens = usageRef.promptTokens;
-                    else if (Array.isArray(data?.messages)) promptTokens = estimateTokensForMessages(data.messages as any);
+                    else if (Array.isArray(data?.messages))
+                        promptTokens = estimateTokensForMessages(data.messages as any);
                 } catch {}
                 let completionTokens: number | null = null;
                 try {
-                    if (usageRef?.completionTokens != null) completionTokens = usageRef.completionTokens;
+                    if (usageRef?.completionTokens != null)
+                        completionTokens = usageRef.completionTokens;
                 } catch {}
                 try {
+                    const { prisma } = await import('@repo/prisma');
                     await prisma.messageLog.create({
                         data: {
                             userId: userId ?? null,
@@ -181,6 +266,11 @@ function createCompletionStream({
             };
 
             try {
+                let t2: number | undefined;
+                let t3: number | undefined;
+                let chunksToFirstTextDelta = 0;
+                let seenFirstTextDelta = false;
+
                 await executeStream({
                     controller,
                     encoder,
@@ -197,12 +287,60 @@ function createCompletionStream({
                             creditCost
                         );
                     },
-                    onUsage: (u) => { usageRef = u || usageRef; },
+                    onUsage: u => {
+                        usageRef = u || usageRef;
+                    },
+                    onTiming: {
+                        onModelCallStart: () => {
+                            if (!t2) t2 = Date.now();
+                        },
+                        onProviderChunk: () => {
+                            if (!seenFirstTextDelta) {
+                                chunksToFirstTextDelta += 1;
+                            }
+                        },
+                        onFirstProviderTextDelta: () => {
+                            if (!seenFirstTextDelta) {
+                                seenFirstTextDelta = true;
+                                t3 = Date.now();
+                            }
+                        },
+                    },
+                    correlationId,
                 });
+
+                // Persist t2/t3 after stream completes
+                (async () => {
+                    try {
+                        const { prisma } = await import('@repo/prisma');
+                        await prisma.telemetryTTFB.update({
+                            where: { correlationId },
+                            data: {
+                                t2: t2 ? new Date(t2) : null,
+                                t3: t3 ? new Date(t3) : null,
+                                modelTTFBMs: t2 && t3 ? t3 - t2 : null,
+                            },
+                        });
+                    } catch (e) {
+                        console.warn('Failed to update TelemetryTTFB (t2/t3):', e);
+                    }
+                })();
+
                 await logMessage('COMPLETED');
+
+                (async () => {
+                    try {
+                        const { prisma } = await import('@repo/prisma');
+                        await prisma.telemetryTTFB.update({
+                            where: { correlationId },
+                            data: { totalMs: Date.now() - t0 },
+                        });
+                    } catch (e) {
+                        console.warn('Failed to update TelemetryTTFB (totalMs):', e);
+                    }
+                })();
             } catch (error) {
                 if (abortController.signal.aborted) {
-                    console.log('abortController.signal.aborted');
                     await logMessage('ABORTED');
                     sendMessage(controller, encoder, {
                         type: 'done',
@@ -212,7 +350,6 @@ function createCompletionStream({
                         parentThreadItemId: data.parentThreadItemId,
                     });
                 } else {
-                    console.log('sending error message');
                     const errMsg = error instanceof Error ? error.message : String(error);
                     await logMessage('ERROR', errMsg);
                     sendMessage(controller, encoder, {
@@ -232,7 +369,6 @@ function createCompletionStream({
             }
         },
         cancel() {
-            console.log('cancelling stream');
             abortController.abort();
         },
     });

--- a/apps/web/app/api/completion/types.ts
+++ b/apps/web/app/api/completion/types.ts
@@ -33,4 +33,5 @@ export const SSE_HEADERS = {
     'Access-Control-Allow-Methods': 'POST, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type, Accept',
     'X-Accel-Buffering': 'no',
+    'Content-Encoding': 'identity',
 } as const;

--- a/apps/web/app/api/telemetry/ttfb/route.ts
+++ b/apps/web/app/api/telemetry/ttfb/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { correlationId, t5, t6, userAgent, rttApprox, deviceHints } = body || {};
+
+    if (!correlationId) {
+      return new Response(
+        JSON.stringify({ error: 'Missing correlationId' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    try {
+      const { prisma } = await import('@repo/prisma');
+      await prisma.telemetryTTFB.upsert({
+        where: { correlationId },
+        create: {
+          correlationId,
+          mode: 'unknown',
+          clientInfo: { t5OffsetMs: t5 ?? null, t6OffsetMs: t6 ?? null, userAgent, rttApprox, deviceHints },
+        },
+        update: {
+          clientInfo: { t5OffsetMs: t5 ?? null, t6OffsetMs: t6 ?? null, userAgent, rttApprox, deviceHints },
+        },
+      });
+    } catch (e) {
+      console.warn('Failed to persist TTFB telemetry (server)', e);
+    }
+
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ error: 'Invalid JSON', details: String(error) }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}
+
+export const runtime = process.env.EDGE_RUNTIME === 'true' ? 'edge' : 'nodejs';

--- a/packages/ai/workflow/tasks/classification.ts
+++ b/packages/ai/workflow/tasks/classification.ts
@@ -21,6 +21,7 @@ export const classificationTask = createTask<WorkflowEventSchema, WorkflowContex
             onChunk: (chunk) => {
                 updateAnswer({ text: chunk, status: 'PENDING' });
             },
+            onTiming: context?.get('onTiming'),
         });
 
         updateAnswer({

--- a/packages/ai/workflow/tasks/completion.ts
+++ b/packages/ai/workflow/tasks/completion.ts
@@ -111,7 +111,9 @@ export const completionTask = createTask<WorkflowEventSchema, WorkflowContextSch
         });
 
         const chunkBuffer = new ChunkBuffer({
-            threshold: 200,
+            threshold: parseInt(process.env.STREAM_FIRST_TOKEN_THRESHOLD_NEXT || '150', 10),
+            thresholdInitial: parseInt(process.env.STREAM_FIRST_TOKEN_THRESHOLD_INITIAL || '1', 10),
+            flushFirstTokenImmediately: (process.env.STREAM_FIRST_TOKEN_IMMEDIATE || 'true').toLowerCase() !== 'false',
             breakOn: ['\n'],
             onFlush: (text: string) => {
                 events?.update('answer', current => ({
@@ -140,6 +142,7 @@ export const completionTask = createTask<WorkflowEventSchema, WorkflowContextSch
                 const u = context.get('onUsage');
                 if (u) u(usage);
             },
+            onTiming: context.get('onTiming'),
         });
 
         reasoningBuffer.end();

--- a/packages/ai/workflow/tasks/correction.ts
+++ b/packages/ai/workflow/tasks/correction.ts
@@ -116,6 +116,7 @@ Appliquez cette méthodologie avec la plus grande rigueur à la liste de libell�
             onChunk: (chunk) => {
                 updateAnswer({ text: chunk, status: 'PENDING' });
             },
+            onTiming: context?.get('onTiming'),
         });
 
         updateAnswer({

--- a/packages/ai/workflow/tasks/nomenclature-douaniere.ts
+++ b/packages/ai/workflow/tasks/nomenclature-douaniere.ts
@@ -20,6 +20,7 @@ export const nomenclatureDouaniereTask = createTask<WorkflowEventSchema, Workflo
             onChunk: (chunk) => {
                 updateAnswer({ text: chunk, status: 'PENDING' });
             },
+            onTiming: context?.get('onTiming'),
         });
 
         updateAnswer({

--- a/packages/ai/workflow/tasks/pro-search.ts
+++ b/packages/ai/workflow/tasks/pro-search.ts
@@ -178,7 +178,7 @@ export const proSearchTask = createTask<WorkflowEventSchema, WorkflowContextSche
                         return acc;
                     }, []),
                     signal,
-                    { batchSize: 4, maxPages: 8, timeout: 30000 }
+                    { batchSize: 3, maxPages: parseInt(process.env.WEBSEARCH_MAX_PAGES || '3', 10), timeout: parseInt(process.env.WEBSEARCH_READ_TIMEOUT_MS || '10000', 10) }
                 );
 
                 if (!webPageContent || webPageContent.length === 0) {

--- a/packages/ai/workflow/tasks/quick-search.ts
+++ b/packages/ai/workflow/tasks/quick-search.ts
@@ -163,7 +163,7 @@ export const quickSearchTask = createTask<WorkflowEventSchema, WorkflowContextSc
 
         const webpageReader = await readWebPagesWithTimeout(
             results.map((result: any) => result?.link),
-            30000
+            parseInt(process.env.WEBSEARCH_READ_TIMEOUT_MS || '10000', 10)
         );
 
         // Mark read as COMPLETED and wrapup as PENDING

--- a/packages/ai/workflow/tasks/web-search.ts
+++ b/packages/ai/workflow/tasks/web-search.ts
@@ -52,9 +52,9 @@ export const webSearchTask = createTask<WorkflowEventSchema, WorkflowContextSche
         });
 
         const processedResults = await processWebPages(results, signal, {
-            timeout: 50000,
-            batchSize: 5,
-            maxPages: 10,
+            timeout: parseInt(process.env.WEBSEARCH_READ_TIMEOUT_MS || '10000', 10),
+            batchSize: 3,
+            maxPages: parseInt(process.env.WEBSEARCH_MAX_PAGES || '3', 10),
         });
 
         if (!processedResults || processedResults.length === 0) {

--- a/packages/orchestrator/engine.ts
+++ b/packages/orchestrator/engine.ts
@@ -408,6 +408,9 @@ export class WorkflowEngine<
     }
 
     getTimingSummary() {
-        return this.executionContext.getMainTimingSummary();
+        return {
+            main: this.executionContext.getMainTimingSummary(),
+            tasks: this.executionContext.getTaskTimingsRaw(),
+        };
     }
 }

--- a/packages/orchestrator/execution-context.ts
+++ b/packages/orchestrator/execution-context.ts
@@ -165,6 +165,20 @@ export class ExecutionContext {
         return parseFloat(value) * multiplier;
     }
 
+    getTaskTimingsRaw(): Record<string, Array<{ startTime?: number; endTime?: number; duration?: number; status: string; error?: string }>> {
+        const out: Record<string, Array<{ startTime?: number; endTime?: number; duration?: number; status: string; error?: string }>> = {};
+        this.taskTimings.forEach((timings, name) => {
+            out[name] = timings.map(t => ({
+                startTime: t.startTime,
+                endTime: t.endTime,
+                duration: t.duration,
+                status: t.status,
+                error: t.error ? (t.error.message || String(t.error)) : undefined,
+            }));
+        });
+        return out;
+    }
+
     getMainTimingSummary(): {
         totalRuns: number;
         totalFailures: number;

--- a/packages/prisma/migrations/20251001090000_add_telemetry_ttfb/migration.sql
+++ b/packages/prisma/migrations/20251001090000_add_telemetry_ttfb/migration.sql
@@ -1,0 +1,29 @@
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "TelemetryTTFB" (
+  "id" TEXT PRIMARY KEY,
+  "correlationId" TEXT NOT NULL UNIQUE,
+  "userId" TEXT,
+  "mode" TEXT NOT NULL,
+  "provider" TEXT,
+  "model" TEXT,
+  "region" TEXT,
+  "t0" TIMESTAMP,
+  "t1" TIMESTAMP,
+  "t2" TIMESTAMP,
+  "t3" TIMESTAMP,
+  "t4" TIMESTAMP,
+  "t5" TIMESTAMP,
+  "t6" TIMESTAMP,
+  "preProcessingMs" INTEGER,
+  "modelTTFBMs" INTEGER,
+  "serverTTFBMs" INTEGER,
+  "totalMs" INTEGER,
+  "clientInfo" JSONB,
+  "createdAt" TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS "TelemetryTTFB_createdAt_idx" ON "TelemetryTTFB" ("createdAt");
+CREATE INDEX IF NOT EXISTS "TelemetryTTFB_mode_idx" ON "TelemetryTTFB" ("mode");
+CREATE INDEX IF NOT EXISTS "TelemetryTTFB_provider_idx" ON "TelemetryTTFB" ("provider");
+CREATE INDEX IF NOT EXISTS "TelemetryTTFB_userId_idx" ON "TelemetryTTFB" ("userId");

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -122,3 +122,31 @@ model MessageLog {
   @@index([userId])
   @@index([status])
 }
+
+model TelemetryTTFB {
+  id             String   @id @default(cuid())
+  correlationId  String   @unique
+  userId         String?
+  mode           String
+  provider       String?
+  model          String?
+  region         String?
+  t0             DateTime?
+  t1             DateTime?
+  t2             DateTime?
+  t3             DateTime?
+  t4             DateTime?
+  t5             DateTime?
+  t6             DateTime?
+  preProcessingMs Int?
+  modelTTFBMs     Int?
+  serverTTFBMs    Int?
+  totalMs         Int?
+  clientInfo      Json?
+  createdAt       DateTime @default(now())
+
+  @@index([createdAt])
+  @@index([mode])
+  @@index([provider])
+  @@index([userId])
+}


### PR DESCRIPTION
# Reduce streaming TTFB to < 1s (Gemini 2.5 Flash)

Summary
- Goal: achieve median Time-To-First-Token (TTFB) < 1s on streaming modes (completion, classification, correction, nomenclature), with early user feedback for web-search modes.
- Approach: end-to-end instrumentation (t0→t6), immediate SSE init event + flush, first-token flush bypassing buffer, anti-buffering headers, optional Edge runtime, web-search pre-stream latency tuning, and richer workflow metrics.

Why
- Users perceive responsiveness from the time the stream opens and the first token appears. We measure and optimize every step (server intake, validation, model start, first provider chunk, first server write, first client event, first paint) to consistently hit < 1s.

Key changes
1) Server-side TTFB instrumentation + SSE init flush
- apps/web/app/api/completion/route.ts
  - t0 at request entry, t1 before workflow/model start.
  - Generate correlationId; immediately send SSE event:init { correlationId, server:{t0,t1}, mode, model, provider, region } and flush to open the stream.
  - Persist initial server timing to TelemetryTTFB (preProcessingMs=t1−t0, serverTTFBMs=t4−t0).
  - Wire onTiming callbacks down to model streaming to capture t2 (model call start) and t3 (first provider text delta). Persist modelTTFBMs=t3−t2. Persist totalMs at end.
  - Export runtime via EDGE_RUNTIME; dynamic Prisma import and guarded persistence to be Edge‑friendly.
- apps/web/app/api/completion/types.ts
  - SSE headers hardened: Content-Type, Cache-Control no-transform, Connection keep-alive, X-Accel-Buffering no, Content-Encoding identity.
- apps/web/app/api/completion/stream-handlers.ts
  - Early non-blocking "status" event (searching) to keep the stream active in search modes.
  - Final "metrics" event with workflow timings.

2) First-token immediate flush (bypass initial buffer)
- packages/ai/workflow/utils.ts
  - ChunkBuffer supports flushFirstTokenImmediately (default true), thresholdInitial (env), thresholdNext (env). First text delta flushes immediately, then buffering resumes to avoid fragmentation.
  - generateText now accepts onTiming callbacks (onModelCallStart, onProviderChunk, onFirstProviderTextDelta) to drive t2/t3.
- packages/ai/workflow/tasks/*
  - completion/classification/correction/nomenclature: wire onTiming from context and configure ChunkBuffer with env thresholds.

3) Client TTFB instrumentation (t5/t6) + telemetry endpoint
- packages/common/hooks/agent-provider.tsx
  - Capture correlationId and t5 on event:init; measure t6 on first answer render (requestAnimationFrame) and POST to /api/telemetry/ttfb.
  - Added support for parsing new events (init, metrics).
- apps/web/app/api/telemetry/ttfb/route.ts (new)
  - POST { correlationId, t5, t6, userAgent, rttApprox?, deviceHints? } upserts into TelemetryTTFB.clientInfo.

4) Web search tuning (lower pre-stream latency)
- packages/ai/workflow/utils.ts
  - SERP timeout configurable (WEBSEARCH_TIMEOUT_SERP_MS, default 5s), in-memory 5‑min cache, early return.
  - Reader/processWebPages tuned: batch 3, max pages configurable (WEBSEARCH_MAX_PAGES, default 3), read timeout (WEBSEARCH_READ_TIMEOUT_MS, default 10s).
- tasks quick-search/pro-search/web-search updated accordingly.

5) Workflow metrics exposure
- packages/orchestrator/execution-context.ts & engine.ts
  - Added raw task timings access; getTimingSummary now returns { main, tasks }.
  - stream-handlers sends a final "metrics" event (non-blocking).

Data model / Persistence
- packages/prisma/schema.prisma
  - New TelemetryTTFB model storing correlationId, t0..t6 (nullable), derived metrics (preProcessingMs, modelTTFBMs, serverTTFBMs, totalMs) and clientInfo JSON.
- packages/prisma/migrations/20251001090000_add_telemetry_ttfb/migration.sql
  - Migration script to create TelemetryTTFB (with indexes).

Environment variables
- STREAM_FIRST_TOKEN_IMMEDIATE=true
- STREAM_FIRST_TOKEN_THRESHOLD_INITIAL=1
- STREAM_FIRST_TOKEN_THRESHOLD_NEXT=150
- WEBSEARCH_TIMEOUT_SERP_MS=5000
- WEBSEARCH_MAX_PAGES=3
- WEBSEARCH_READ_TIMEOUT_MS=10000
- EDGE_RUNTIME=true (opt‑in, fallback to node for Prisma/SDK constraints)

Backward compatibility & impact
- SSE contract for text-delta unchanged. New events: init, status (early), metrics (final), fully backward‑compatible.
- Compression disabled for text/event-stream to avoid buffering; hardened headers.
- Edge runtime optional via flag; code guards Prisma usage with dynamic import for Edge compatibility. If incompatibility is detected at runtime, streaming still proceeds, persistence is skipped with a warning.
- DB migration required for TelemetryTTFB; does not affect existing MessageLog.

Acceptance criteria mapping
- Modes sans recherche: init ≤ 150ms; first text-delta ≤ 1s in ≥90% (with first-token flush + anti‑buffering headers + init flush).
- Modes avec recherche: init ≤ 150ms; early status ≤ 500ms (status event + search timeouts);
- Telemetry: server t0..t4 persisted; client t5..t6 posted (≥80% coverage) via correlationId.

Verification plan
- Manual: observe event:init arrival time and first token paint; verify TelemetryTTFB rows are written with correlationId; confirm done + metrics events.
- Bench (optional next step): run 50 requests across modes and compute median/p90 TTFB.

Notes
- If Edge runtime is not desired, keep EDGE_RUNTIME=false; the streaming behaviour and instrumentation still work on Node.
- If you prefer minimal DB changes, TelemetryTTFB fields can be folded into a JSON column in MessageLog; this PR uses a separate table for clarity.

Type of change
- Enhancement/Performance, Observability, Minor API (SSE events added), DB migration



₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/ab88df8b-ecc7-4797-ac03-6cf4db9dd898/task/3b93de47-90ca-4eab-a085-adb1dbd98623))