### PR TITLE
ECART_TIC: limite import .xlsx 15MB + résumé basé sur budgets ajustés

### DIFF
--- a/packages/ai/workflow/tasks/ecart-tic.ts
+++ b/packages/ai/workflow/tasks/ecart-tic.ts
@@ -283,7 +283,7 @@ ${catList}
     const journalRows = journal.map(j => [j.article, j.amount, categories[j.from].name, categories[j.to].name, j.reason, j.step]);
 
     const resumeHeader = ['Indicateur', 'Valeur'];
-    const finalBudgetTotal = adjustedBudgets ? Object.values(adjustedBudgets).reduce((a, b) => a + b, 0) : sumBudget;
+    const finalBudgetTotal = catKeys.reduce((sum, k) => sum + (adjustedBudgets?.[k] ?? categories[k].budget), 0);
     const finalGlobalDiff = finalBudgetTotal - sumTotals;
     const categoriesBalanced = bilanRows.filter(r => r[5] === '✅ Équilibré').length;
     const resumeRows = [

--- a/packages/common/components/chat-input/file-import.tsx
+++ b/packages/common/components/chat-input/file-import.tsx
@@ -189,8 +189,8 @@ export const FileImportIcon: React.FC = () => {
           toast({ title: 'Format non supporté. Importez un .xlsx', variant: 'destructive' });
           return;
         }
-        if (file.size > 5 * 1024 * 1024) {
-          toast({ title: 'Fichier trop volumineux (>5 MB)', variant: 'destructive' });
+        if (file.size > 15 * 1024 * 1024) {
+          toast({ title: 'Fichier trop volumineux (>15 MB)', variant: 'destructive' });
           return;
         }
         const reader = new FileReader();


### PR DESCRIPTION
Résumé
- Défense en profondeur: limite serveur 15MB sur l’import .xlsx (estimation base64 + vérification binaire) et alignement côté client.
- Correction du résumé après réallocation: les totaux affichés s’appuient sur les budgets ajustés quand ils existent.

Détails des changements
- packages/ai/workflow/tasks/ecart-tic.ts
  - Ajout d’une limite 15MB avant décodage (estimation base64) puis double vérification après décodage (Buffer.length). Message d’erreur en français: « Fichier trop volumineux (>15MB). Veuillez fournir un .xlsx ≤ 15MB. »
  - Calcul des valeurs finales pour le « Résumé global »:
    - Total Budgets = somme(adjustedBudgets) si présent, sinon sumBudget.
    - Écart Global = Total Budgets final − somme des montants alloués.
  - Mise à jour du tableau Résumé et de l’objet summary envoyé à l’UI.
- apps/web/app/api/completion/route.ts
  - Validation précoce pour le mode ECART_TIC: scan des messages pour détecter un .xlsx encodé en base64 et rejet en 400 si >15MB (sans lancer le workflow).
- packages/common/components/chat-input/file-import.tsx
  - Seuil porté de 5MB à 15MB pour ECART_TIC et toast ajusté (« Fichier trop volumineux (>15 MB) »).

Pourquoi
- Éviter les OOM/DoS via des pièces jointes trop lourdes.
- Assurer une UX cohérente (15MB côté client) et un contrôle serveur fiable (double check).
- Garantir que le résumé reflète les budgets ajustés après réallocation, tant dans l’onglet « Résumé global » que dans l’aperçu markdown et dans summary envoyé à l’UI.

Critères d’acceptation couverts
- .xlsx ≤ 15MB accepté, >15MB rejeté côté client et/ou API/tâche avec message explicite.
- Si adjustedBudgets est défini: « Total Budgets » = somme(adjustedBudgets), « Écart Global » = somme(adjustedBudgets) − sumTotals.
- Si adjustedBudgets n’est pas défini: le résumé reste basé sur sumBudget.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/1cc49c22-4b4c-42f9-a987-006d3197d188/task/81d91901-adea-493b-8bd4-428680240bdb))
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Limite l’import .xlsx à 15MB pour ECART_TIC et corrige le résumé pour s’appuyer sur les budgets ajustés après réallocation. Empêche les uploads trop lourds et aligne les totaux affichés avec les budgets finalisés.

- **New Features**
  - API: rejet précoce des .xlsx encodés en base64 >15MB avec message d’erreur clair.
  - Tâche ECART_TIC: double vérification de taille (estimation base64 + Buffer) avant parsing.
  - Client: seuil porté à 15MB et toast mis à jour.

- **Bug Fixes**
  - « Total Budgets » et « Écart Global » calculés depuis adjustedBudgets quand disponible; sinon basés sur sumBudget.
  - Le tableau « Résumé » et l’objet summary envoyés à l’UI reflètent ces valeurs.

<!-- End of auto-generated description by cubic. -->

