### PR TITLE
Fix TS build: define MAX_XLSX_SIZE in ecart-tic task

### DIFF
--- a/packages/ai/workflow/tasks/ecart-tic.ts
+++ b/packages/ai/workflow/tasks/ecart-tic.ts
@@ -82,6 +82,8 @@ const tryParseJsonFallback = (text: string): { articles: Article[]; budgetsRows:
   return null;
 };
 
+const MAX_XLSX_SIZE = 15 * 1024 * 1024;
+
 const TOLERANCE = 2;
 
 export const ecartTicTask = createTask<WorkflowEventSchema, WorkflowContextSchema>({


### PR DESCRIPTION
Fix Vercel TypeScript error by defining `MAX_XLSX_SIZE` locally in `packages/ai/workflow/tasks/ecart-tic.ts`.

Changes
- Define `MAX_XLSX_SIZE = 15 * 1024 * 1024` to enforce a 15 MB XLSX limit.
- Aligns with the same limit already used in `apps/web/app/api/completion/route.ts`.
- Preserves the existing 5 MB base64 pre-validation, then applies the 15 MB cap on decoded buffer size.

Impact
- Vercel build should pass (TypeScript error resolved).
- Oversized XLSX files now yield a clear error message (>15 MB).


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/1cc49c22-4b4c-42f9-a987-006d3197d188/task/bb871b56-0f57-431f-9e5a-1460791ae8d5))
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes TypeScript build on Vercel by defining MAX_XLSX_SIZE in the ecart-tic task and enforcing a 15 MB XLSX limit consistent with the API route. Keeps the 5 MB base64 pre-check, then applies the 15 MB cap on the decoded buffer with a clear error if exceeded.

<!-- End of auto-generated description by cubic. -->

