### PR TITLE
Pause site: Add professional upgrade message for exceeded quota

### DIFF
--- a/apps/web/app/maintenance/page.tsx
+++ b/apps/web/app/maintenance/page.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+export default function MaintenancePage() {
+    return (
+        <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-900 to-slate-800 py-12 px-4 sm:px-6 lg:px-8">
+            <div className="max-w-2xl w-full space-y-8">
+                <div className="text-center space-y-4">
+                    <div className="inline-flex items-center justify-center w-16 h-16 bg-amber-500/10 rounded-full">
+                        <svg className="w-8 h-8 text-amber-500" fill="currentColor" viewBox="0 0 20 20">
+                            <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+                        </svg>
+                    </div>
+                    <h1 className="text-4xl font-bold text-white">
+                        Utilisation du service
+                    </h1>
+                    <p className="text-lg text-amber-400 font-semibold">
+                        CPU Fluid Active
+                    </p>
+                </div>
+
+                <div className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl py-8 px-6 sm:px-8 space-y-6">
+                    <div className="space-y-3">
+                        <div className="flex items-center justify-between">
+                            <span className="text-gray-300">Durée d'utilisation</span>
+                            <span className="text-xl font-semibold text-white">4h 25m / 4h</span>
+                        </div>
+                        <div className="w-full bg-gray-700 rounded-full h-3 overflow-hidden">
+                            <div className="bg-gradient-to-r from-red-500 to-orange-500 h-full rounded-full" style={{ width: '110%' }}></div>
+                        </div>
+                        <p className="text-sm text-red-400">Quota dépassé</p>
+                    </div>
+
+                    <div className="border-t border-white/10 pt-6">
+                        <p className="text-gray-200 text-center leading-relaxed">
+                            Vous avez dépassé votre quota d'utilisation alloué. Afin de continuer à bénéficier du service sans interruption, nous vous invitons à passer à la version payante au tarif de <span className="font-semibold text-white">120 $/mois</span>.
+                        </p>
+                    </div>
+
+                    <div className="bg-blue-500/10 border border-blue-500/20 rounded-lg p-4">
+                        <p className="text-blue-200 text-sm text-center">
+                            N'hésitez pas à poser vos questions à <span className="font-semibold">Arka Sam</span> pour toute information complémentaire.
+                        </p>
+                    </div>
+                </div>
+
+                <div className="text-center space-y-4">
+                    <p className="text-gray-400 text-sm">
+                        Pour reprendre le service, veuillez contacter l'administrateur.
+                    </p>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,5 +1,47 @@
 'use client';
 
+const IS_PAUSED = true;
+
 export default function Home() {
-    return <></>;
+    if (!IS_PAUSED) {
+        return <></>;
+    }
+
+    return (
+        <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+            <div className="max-w-md w-full space-y-8">
+                <div>
+                    <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+                        Utilisation du service
+                    </h2>
+                    <p className="mt-2 text-center text-sm text-gray-600">
+                        CPU Fluid Active
+                    </p>
+                    <p className="mt-1 text-center text-lg text-gray-900 font-medium">
+                        Durée d'utilisation : 4h 25m / 4h
+                    </p>
+                </div>
+                <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
+                    <div className="space-y-6">
+                        <p className="text-gray-700 text-center">
+                            Vous avez dépassé votre quota d'utilisation alloué. Afin de continuer à bénéficier du service sans interruption, nous vous invitons à passer à la version payante au tarif de 120 $/mois.
+                        </p>
+                        <div className="text-center">
+                            <p className="text-sm text-gray-600">
+                                N'hésitez pas à poser vos questions à Arka Sam pour toute information complémentaire.
+                            </p>
+                            <a href="mailto:arka@sam.com" className="mt-2 inline-block text-blue-600 hover:text-blue-500 text-sm font-medium">
+                                Contactez-nous
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div className="text-center text-sm text-gray-500">
+                    <p>
+                        Pour reprendre le site, modifiez ce fichier et mettez IS_PAUSED à false.
+                    </p>
+                </div>
+            </div>
+        </div>
+    );
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,47 +1,7 @@
 'use client';
 
-const IS_PAUSED = true;
+'use client';
 
 export default function Home() {
-    if (!IS_PAUSED) {
-        return <></>;
-    }
-
-    return (
-        <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-            <div className="max-w-md w-full space-y-8">
-                <div>
-                    <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
-                        Utilisation du service
-                    </h2>
-                    <p className="mt-2 text-center text-sm text-gray-600">
-                        CPU Fluid Active
-                    </p>
-                    <p className="mt-1 text-center text-lg text-gray-900 font-medium">
-                        Durée d'utilisation : 4h 25m / 4h
-                    </p>
-                </div>
-                <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
-                    <div className="space-y-6">
-                        <p className="text-gray-700 text-center">
-                            Vous avez dépassé votre quota d'utilisation alloué. Afin de continuer à bénéficier du service sans interruption, nous vous invitons à passer à la version payante au tarif de 120 $/mois.
-                        </p>
-                        <div className="text-center">
-                            <p className="text-sm text-gray-600">
-                                N'hésitez pas à poser vos questions à Arka Sam pour toute information complémentaire.
-                            </p>
-                            <a href="mailto:arka@sam.com" className="mt-2 inline-block text-blue-600 hover:text-blue-500 text-sm font-medium">
-                                Contactez-nous
-                            </a>
-                        </div>
-                    </div>
-                </div>
-                <div className="text-center text-sm text-gray-500">
-                    <p>
-                        Pour reprendre le site, modifiez ce fichier et mettez IS_PAUSED à false.
-                    </p>
-                </div>
-            </div>
-        </div>
-    );
+    return <></>;
 }

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from 'next/server';
 
 export const runtime = 'nodejs';
 
-const SITE_PAUSED = false;
+const SITE_PAUSED = true;
 
 export default function middleware(req: NextRequest) {
   const url = new URL(req.url);

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -3,6 +3,8 @@ import type { NextRequest } from 'next/server';
 
 export const runtime = 'nodejs';
 
+const SITE_PAUSED = true;
+
 export default function middleware(req: NextRequest) {
   const url = new URL(req.url);
 
@@ -12,6 +14,7 @@ export default function middleware(req: NextRequest) {
     pathname.startsWith('/api/auth') ||
     pathname.startsWith('/api/completion') ||
     pathname === '/sign-in' ||
+    pathname === '/maintenance' ||
     pathname.startsWith('/_next/static') ||
     pathname.startsWith('/_next/image') ||
     pathname === '/favicon.ico' ||
@@ -20,6 +23,13 @@ export default function middleware(req: NextRequest) {
     pathname === '/manifest.json'
   ) {
     return NextResponse.next();
+  }
+
+  // If site is paused, redirect to maintenance
+  if (SITE_PAUSED) {
+    url.pathname = '/maintenance';
+    url.search = '';
+    return NextResponse.redirect(url);
   }
 
   // Require session cookie for everything else

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from 'next/server';
 
 export const runtime = 'nodejs';
 
-const SITE_PAUSED = true;
+const SITE_PAUSED = false;
 
 export default function middleware(req: NextRequest) {
   const url = new URL(req.url);


### PR DESCRIPTION


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/b5f69b95-510d-49cc-9473-3953e0c8aed5/task/3ca32c59-e046-41a2-a002-835cce18a5fa))







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pause the site by redirecting all traffic to a professional maintenance screen that explains the exceeded usage quota and prompts an upgrade at $120/month. Adds a SITE_PAUSED flag in middleware to easily toggle the pause (set to false to unpause).

<sup>Written for commit 53d3a520a1c663963d4ce7d0e92c2502fb6e2691. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







